### PR TITLE
Use django-cms from git main branch

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -12,7 +12,7 @@ whitenoise
 easy-thumbnails
 
 # key requirements for django CMS
-django-cms
+git+https://github.com/django-cms/django-cms@main
 djangocms-versioning
 djangocms-alias
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,14 +40,13 @@ django==5.2.6
     #   django-taggit
     #   django-taggit-templatetags
     #   django-treebeard
-    #   djangocms-admin-style
     #   djangocms-versioning
     #   easy-thumbnails
 django-classy-tags==4.1.0
     # via
     #   django-cms
     #   django-sekizai
-django-cms==5.0.5
+django-cms @ git+https://github.com/django-cms/django-cms@main
     # via
     #   -r requirements.in
     #   djangocms-alias
@@ -101,8 +100,6 @@ django-templatetag-sugar==1.0
     # via django-taggit-templatetags
 django-treebeard==4.7.1
     # via django-cms
-djangocms-admin-style==3.3.1
-    # via django-cms
 djangocms-alias==3.0.1
     # via -r requirements.in
 djangocms-attributes-field==4.1.1
@@ -148,7 +145,6 @@ orderedmultidict==1.0.1
 packaging==25.0
     # via
     #   build
-    #   django-cms
     #   djangocms-text
     #   djangocms-versioning
 pillow==11.3.0


### PR DESCRIPTION
## Summary
- Switch django-cms from PyPI package to git main branch to use the latest development version

## Test plan
- [x] Verify pip install works with the updated requirements
- [x] Confirm the application runs correctly with the git version of django-cms

🤖 Generated with [Claude Code](https://claude.com/claude-code)