### PR TITLE
feat: update navbar and footer link styles for improved layout

### DIFF
--- a/backend/static/scss/_navbar.scss
+++ b/backend/static/scss/_navbar.scss
@@ -281,3 +281,27 @@
     }
   }
 }
+
+.navbar-nav.list-unstyled,
+.navbar-nav.list-unstyled li {
+  list-style: none;
+  list-style-type: none;
+}
+
+.navbar-nav .nav-item::before,
+.navbar-nav .nav-item::marker {
+  display: none;
+  content: none;
+}
+
+.list-link-container.list-unstyled,
+.list-link-container.list-unstyled li {
+  list-style: none;
+  list-style-type: none;
+}
+
+.list-link-container .list-link-item::before,
+.list-link-container .list-link-item::marker {
+  display: none;
+  content: none;
+}

--- a/cms_theme/cms_components.py
+++ b/cms_theme/cms_components.py
@@ -145,11 +145,11 @@ class Footer(CMSFrontendComponent):
 
 
 @components.register
-class FooterLinksList(CMSFrontendComponent):
+class LinksListContainer(CMSFrontendComponent):
     """Footer Links List component"""
 
     class Meta:
-        name = _("Footer Links List")
+        name = _("Links List Container")
         render_template = "footer/footer_links_list.html"
         requires_parent = True
         parent_classes = ["Footer", "GridColumnPlugin"]
@@ -354,8 +354,8 @@ class Navbar(CMSFrontendComponent):
         label=_("Logo Image"),
         required=False,
     )
-    
-    
+
+
 @components.register
 class RelatedPeople(CMSFrontendComponent):
     """Related People component"""

--- a/cms_theme/templates/footer/footer_links_list.html
+++ b/cms_theme/templates/footer/footer_links_list.html
@@ -1,10 +1,10 @@
 {% load cms_tags cms_theme_tags %}
 
-<nav class="{{ instance.get_classes }}" {{ instance.get_attributes }}>
+<nav class="{{ instance.get_classes }} list-link-container" {{ instance.get_attributes }}>
     <ul class="list-unstyled m-0 d-flex {{ instance.config.item_alignment|default:'flex-column' }}{% if instance.config.item_spacing %} gap-{{ instance.config.item_spacing }}{% endif %}"
-        role="list">
+        role="list" style="list-style: none;">
         {% for plugin in instance.child_plugin_instances %}
-            <li class="footer-link-item">
+            <li class="list-link-item">
                 {% render_plugin plugin %}
             </li>
         {% endfor %}

--- a/cms_theme/templates/navbar/navbar.html
+++ b/cms_theme/templates/navbar/navbar.html
@@ -17,7 +17,7 @@
 
     <div class="collapse navbar-collapse" id="navbarNavAltMarkup">
       {# Links #}
-      <ul class="navbar-nav">
+      <ul class="navbar-nav list-unstyled">
         {% show_menu 0 1 100 100 "menu/menu.html" %}
       </ul>
 


### PR DESCRIPTION
This pull request refactors the naming and styling of link list containers in both the footer and navbar components to improve semantic clarity and ensure consistent, accessible list formatting. The changes include renaming the footer links list component, updating template class names, and applying CSS rules to remove default list styles and markers.

Component and template refactoring:
* Renamed the `FooterLinksList` class to `LinksListContainer` for broader semantic use, and updated its display name in the `Meta` class (`cms_theme/cms_components.py`).
* Updated the `footer_links_list.html` template to use the new `list-link-container` and `list-link-item` class names, and ensured the `<ul>` element uses `list-unstyled` and inline `list-style: none` for consistent styling (`cms_theme/templates/footer/footer_links_list.html`).

Navbar and footer list styling:
* Changed the navbar `<ul>` to use the `list-unstyled` class for removing default list styles (`cms_theme/templates/navbar/navbar.html`).
* Added SCSS rules to `.navbar-nav.list-unstyled`, `.navbar-nav.list-unstyled li`, `.list-link-container.list-unstyled`, and `.list-link-container.list-unstyled li` to remove list styles and markers, ensuring clean, marker-free navigation and footer lists (`backend/static/scss/_navbar.scss`).