### PR TITLE
feat: remove list styling from timeline component for improved semantics

### DIFF
--- a/backend/static/scss/_timeline.scss
+++ b/backend/static/scss/_timeline.scss
@@ -6,7 +6,6 @@ $timeline-circle-size: 15px;
 // Main timeline wrapper
 .main-timeline {
   position: relative;
-  list-style: none;
   padding: 0;
   margin: 0;
 

--- a/cms_theme/templates/timeline/timeline.html
+++ b/cms_theme/templates/timeline/timeline.html
@@ -13,17 +13,17 @@
             {% endif %}
         {% endfor %}
 
-        {# Timeline items as ordered list for semantic structure #}
-        <ol class="main-timeline timeline-divider-{{ instance.config.divider_color|default:'primary' }} timeline-circle-{{ instance.config.circle_color|default:'secondary' }}" role="list">
+        {# Timeline items #}
+        <div class="main-timeline timeline-divider-{{ instance.config.divider_color|default:'primary' }} timeline-circle-{{ instance.config.circle_color|default:'secondary' }}" role="list">
             {% for child in instance.child_plugin_instances %}
                 {% if child.plugin_type == "CardPlugin" and child.child_plugin_instances %}
-                    <li class="timeline {% cycle 'timeline-right' 'timeline-left' %}" role="listitem">
+                    <div class="timeline {% cycle 'timeline-right' 'timeline-left' %}" role="listitem">
                         {% render_plugin child %}
-                    </li>
+                    </div>
                 {% endif %}
             {% empty %}
                 {# No timeline items #}
             {% endfor %}
-        </ol>
+        </div>
     </div>
 </section>


### PR DESCRIPTION
This pull request updates the timeline component's HTML structure from using an ordered list (`<ol>`) and list items (`<li>`) to using `<div>` elements, and removes the `list-style` property from the timeline's SCSS. This change improves the flexibility of the timeline layout and simplifies its styling.

**HTML structure changes:**

* Replaced the `<ol>` and `<li>` elements in `timeline.html` with `<div>` containers for timeline items, updating the semantic structure and potentially improving layout flexibility.

**Styling adjustments:**

* Removed the `list-style: none;` property from the `.main-timeline` class in `_timeline.scss`, as the timeline is no longer structured as a list.