### PR TITLE
feat: update admin CSS and improve styling for membership plans and f…

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -320,7 +320,7 @@ STORIES_TEMPLATE_CHOICES = (("blog/post_list.html", _("Default")),)
 
 # djangocms-frontend settings
 DJANGOCMS_FRONTEND_ADMIN_CSS = {
-    "all": ("css/main.css",),
+    "all": ("css/admin_colors.css",),
 }
 
 DJANGOCMS_FRONTEND_ICON_LIBRARIES_SHOWN = (

--- a/backend/static/css/admin_colors.css
+++ b/backend/static/css/admin_colors.css
@@ -1,0 +1,161 @@
+/* Admin Colors - Color utilities for djangocms-frontend admin */
+
+/* ===== Background colors ===== */
+
+/* Theme colors */
+.bg-primary { background-color: #DEFCB9 !important; }
+.bg-secondary { background-color: #2C4D4C !important; }
+.bg-light { background-color: #F7F7F7 !important; }
+.bg-dark { background-color: #212121 !important; }
+.bg-danger { background-color: #D44848 !important; }
+.bg-success { background-color: #198754 !important; }
+.bg-warning { background-color: #ffc107 !important; }
+.bg-info { background-color: #0dcaf0 !important; }
+.bg-white { background-color: #fff !important; }
+.bg-black { background-color: #000 !important; }
+
+/* Custom colors */
+.bg-mid-grey { background-color: #7C7C7C !important; }
+.bg-second-primary { background-color: #214A35 !important; }
+.bg-platinum { background-color: #DEE2D9 !important; }
+.bg-gold { background-color: #F8F246 !important; }
+.bg-silver { background-color: #CCD0C7 !important; }
+.bg-bronze { background-color: #BC5728 !important; }
+
+/* Subtle variants */
+.bg-primary-subtle { background-color: rgba(222, 252, 185, 0.3) !important; }
+.bg-secondary-subtle { background-color: rgba(44, 77, 76, 0.3) !important; }
+.bg-dark-subtle { background-color: rgba(33, 33, 33, 0.3) !important; }
+.bg-danger-subtle { background-color: rgba(212, 72, 72, 0.3) !important; }
+
+/* ===== Button colors ===== */
+
+/* Primary */
+.btn-primary {
+  background-color: #DEFCB9 !important;
+  border-color: #DEFCB9 !important;
+  color: #2C4D4C !important;
+}
+
+/* Secondary */
+.btn-secondary {
+  background-color: #2C4D4C !important;
+  border-color: #2C4D4C !important;
+  color: #fff !important;
+}
+
+/* Light */
+.btn-light {
+  background-color: #F7F7F7 !important;
+  border-color: #F7F7F7 !important;
+  color: #212121 !important;
+}
+
+/* Dark */
+.btn-dark {
+  background-color: #212121 !important;
+  border-color: #212121 !important;
+  color: #fff !important;
+}
+
+/* Danger */
+.btn-danger {
+  background-color: #D44848 !important;
+  border-color: #D44848 !important;
+  color: #fff !important;
+}
+
+/* Success */
+.btn-success {
+  background-color: #198754 !important;
+  border-color: #198754 !important;
+  color: #fff !important;
+}
+
+/* Warning */
+.btn-warning {
+  background-color: #ffc107 !important;
+  border-color: #ffc107 !important;
+  color: #000 !important;
+}
+
+/* Info */
+.btn-info {
+  background-color: #0dcaf0 !important;
+  border-color: #0dcaf0 !important;
+  color: #000 !important;
+}
+
+/* Custom button colors */
+.btn-mid-grey {
+  background-color: #7C7C7C !important;
+  border-color: #7C7C7C !important;
+  color: #fff !important;
+}
+
+.btn-second-primary {
+  background-color: #214A35 !important;
+  border-color: #214A35 !important;
+  color: #fff !important;
+}
+
+.btn-platinum {
+  background-color: #DEE2D9 !important;
+  border-color: #DEE2D9 !important;
+  color: #212121 !important;
+}
+
+.btn-gold {
+  background-color: #F8F246 !important;
+  border-color: #F8F246 !important;
+  color: #212121 !important;
+}
+
+.btn-silver {
+  background-color: #CCD0C7 !important;
+  border-color: #CCD0C7 !important;
+  color: #212121 !important;
+}
+
+.btn-bronze {
+  background-color: #BC5728 !important;
+  border-color: #BC5728 !important;
+  color: #fff !important;
+}
+
+/* Outline button variants */
+.btn-outline-primary {
+  border-color: #DEFCB9 !important;
+  color: #2C4D4C !important;
+  background-color: transparent !important;
+}
+
+.btn-outline-secondary {
+  border-color: #2C4D4C !important;
+  color: #2C4D4C !important;
+  background-color: transparent !important;
+}
+
+.btn-outline-dark {
+  border-color: #212121 !important;
+  color: #212121 !important;
+  background-color: transparent !important;
+}
+
+.btn-outline-danger {
+  border-color: #D44848 !important;
+  color: #D44848 !important;
+  background-color: transparent !important;
+}
+
+/* ===== Text colors ===== */
+
+.text-primary { color: #DEFCB9 !important; }
+.text-secondary { color: #2C4D4C !important; }
+.text-light { color: #F7F7F7 !important; }
+.text-dark { color: #212121 !important; }
+.text-danger { color: #D44848 !important; }
+.text-white { color: #fff !important; }
+.text-black { color: #000 !important; }
+.text-mid-grey { color: #7C7C7C !important; }
+.text-second-primary { color: #214A35 !important; }

--- a/backend/static/scss/_membership_plans.scss
+++ b/backend/static/scss/_membership_plans.scss
@@ -11,7 +11,7 @@
 .accent-box {
   position: absolute;
   top: 0%;
-  left: 3.5%;
+  left: 0%;
   width: 75px;
   height: 74px;
   border-radius: 15px;

--- a/backend/static/scss/_table.scss
+++ b/backend/static/scss/_table.scss
@@ -165,6 +165,6 @@ table tbody tr:last-child td:last-child,
     tbody tr td:nth-child(2),
     tbody tr:nth-child(odd) td:nth-child(2),
     tbody tr:nth-child(even) td:nth-child(2) {
-        background-color: $white !important;
+        background-color: $light-grey !important;
     }
 }

--- a/backend/static/scss/main.scss
+++ b/backend/static/scss/main.scss
@@ -93,3 +93,9 @@
   border-top-right-radius: 0.625rem !important;
   border-bottom-right-radius: 0.625rem !important;
 }
+
+.list-container li,
+list-link-item  {
+  margin: 0;
+  padding: 0;
+}

--- a/cms_theme/templates/footer/footer_links_list.html
+++ b/cms_theme/templates/footer/footer_links_list.html
@@ -1,7 +1,7 @@
 {% load cms_tags cms_theme_tags %}
 
 <nav class="{{ instance.get_classes }} list-link-container" {{ instance.get_attributes }}>
-    <ul class="list-unstyled m-0 d-flex {{ instance.config.item_alignment|default:'flex-column' }}{% if instance.config.item_spacing %} gap-{{ instance.config.item_spacing }}{% endif %}"
+    <ul class="list-unstyled m-0 d-flex list-container {{ instance.config.item_alignment|default:'flex-column' }}{% if instance.config.item_spacing %} gap-{{ instance.config.item_spacing }}{% endif %}"
         role="list" style="list-style: none;">
         {% for plugin in instance.child_plugin_instances %}
             <li class="list-link-item">

--- a/cms_theme/templates/membership/cards/plan_card.html
+++ b/cms_theme/templates/membership/cards/plan_card.html
@@ -1,5 +1,5 @@
 {% load static cms_tags sekizai_tags cms_theme_tags %}
-<div class="col-12 col-md-6 col-xl-3 accent-wrapper mb-7 d-flex justify-content-end">
+<div class="col-12 col-md-6 col-xl-3 accent-wrapper mb-7 d-flex justify-content-end p-0">
     <div class="accent-box accent-{{ instance.tier_color }}"></div>
     <div class="card plan-card p-4 shadow-sm h-100 d-flex flex-column">
         {% if instance.card_heading %}<h3 class="mb-1">{{ instance.card_heading }}</h3>{% endif %}


### PR DESCRIPTION
This pull request updates the color scheme and improves styling consistency for the Django CMS frontend admin and membership plan components. The main changes include introducing a new custom admin color CSS file, updating references to use this file, refining table and list item styles, and making minor layout adjustments to membership plan cards.

**Admin color and style improvements:**

* Added a new `admin_colors.css` file with detailed background, button, and text color utility classes for use in the Django CMS frontend admin.
* Updated the `DJANGOCMS_FRONTEND_ADMIN_CSS` setting in `settings.py` to use the new `admin_colors.css` instead of the previous `main.css`.

**Membership plan and table styling:**

* Adjusted the `.accent-box` positioning in `_membership_plans.scss` to align it to the left edge, improving visual alignment of membership plan cards.
* Added the `p-0` class to the plan card wrapper in `plan_card.html` for better spacing control.
* Changed the background color of the second column in tables from white to light grey in `_table.scss` for improved readability.

**List and footer link styling:**

* Added `.list-container` and `.list-link-item` classes to `main.scss` for consistent list styling, and updated `footer_links_list.html` to use these classes. [[1]](diffhunk://#diff-e95b7d616f5a3ba20e05a11a193a7b011b72c12203511e236cc31134973c0f65R96-R101) [[2]](diffhunk://#diff-e98ffa6d87a8eb39d2113ec1022b45a9e9063a823c6f8e80896824e0a5d15565L4-R4)