### PR TITLE
chore: Update django CMS version requirement

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -12,7 +12,7 @@ whitenoise
 easy-thumbnails
 
 # key requirements for django CMS
-git+https://github.com/django-cms/django-cms@main
+django-cms>=5.1.0a1
 djangocms-versioning
 djangocms-alias
 


### PR DESCRIPTION
Use django CMS 5.1.0a1 (or later)