### PR TITLE
feat: rename LogoCarousel component to Carousel

### DIFF
--- a/cms_theme/cms_components.py
+++ b/cms_theme/cms_components.py
@@ -223,7 +223,7 @@ class LogoCarousel(CMSFrontendComponent):
     """LogoCarousel component"""
 
     class Meta:
-        name = _("Logo Carousel")
+        name = _("Carousel")
         render_template = "carousel/logo_carousel.html"
         allow_children = True
         child_classes = [


### PR DESCRIPTION
This pull request includes a minor update to the `LogoCarousel` component. The change simplifies the display name of the component.

* Changed the `name` attribute in the `LogoCarousel.Meta` class from "Logo Carousel" to "Carousel" for improved clarity and consistency.