### PR TITLE
fix: update hover styles for primary button variant

### DIFF
--- a/backend/static/scss/_buttons.scss
+++ b/backend/static/scss/_buttons.scss
@@ -43,8 +43,8 @@
   &:active,
   &.active {
     background-color: transparent;
-    color: $primary;
-    border: 1px solid $primary;
+    color: $secondary;
+    border: 1px solid $secondary;
   }
 
   &:focus-visible {


### PR DESCRIPTION
This pull request makes a minor adjustment to the button styles in the `_buttons.scss` file. The change updates the color scheme for active buttons.

* Changed the `color` and `border` for active buttons from `$primary` to `$secondary` in `_buttons.scss`.

## Summary by Sourcery

Enhancements:
- Adjust active and .active primary button text and border colors to use the secondary theme color.