### PR TITLE
feat: add hover color changes for collapsed accordion buttons

### DIFF
--- a/backend/static/scss/_accordion.scss
+++ b/backend/static/scss/_accordion.scss
@@ -89,6 +89,10 @@
     &:not(.collapsed) {
       color: var(--bs-primary);
     }
+
+    &.collapsed:hover {
+      color: var(--bs-grey-dark);
+    }
   }
   .accordion-item::before {
     background-color: rgba(var(--bs-primary-rgb), 0.5);
@@ -103,6 +107,10 @@
     color: rgba(var(--bs-secondary-rgb), 0.5);
 
     &:not(.collapsed) {
+      color: var(--bs-secondary);
+    }
+
+    &.collapsed:hover {
       color: var(--bs-secondary);
     }
   }
@@ -121,6 +129,10 @@
     &:not(.collapsed) {
       color: #fff;
     }
+
+    &.collapsed:hover {
+      color: #fff;
+    }
   }
   .accordion-item::before {
     background-color: rgba(255, 255, 255, 0.5);
@@ -137,6 +149,10 @@
     &:not(.collapsed) {
       color: #6c757d;
     }
+
+    &.collapsed:hover {
+      color: #6c757d;
+    }
   }
   .accordion-item::before {
     background-color: rgba(108, 117, 125, 0.5);
@@ -151,6 +167,10 @@
     color: rgba(0, 0, 0, 0.5);
 
     &:not(.collapsed) {
+      color: #000;
+    }
+
+    &.collapsed:hover {
       color: #000;
     }
   }


### PR DESCRIPTION
This pull request makes minor improvements to the accordion component's styling in the `_accordion.scss` file. Specifically, it adds hover color rules for collapsed accordion headers, ensuring color consistency when users hover over collapsed items.

* Accordion header hover styling:
  * Added `&.collapsed:hover` color rules for each color theme, so that collapsed headers display the correct color when hovered. This improves visual feedback and maintains consistency across different themes. [[1]](diffhunk://#diff-9f01b33fcc28f9c5a17633d406190b462e90f75d48d8848ec13cf2e1093322b8R92-R95) [[2]](diffhunk://#diff-9f01b33fcc28f9c5a17633d406190b462e90f75d48d8848ec13cf2e1093322b8R112-R115) [[3]](diffhunk://#diff-9f01b33fcc28f9c5a17633d406190b462e90f75d48d8848ec13cf2e1093322b8R132-R135) [[4]](diffhunk://#diff-9f01b33fcc28f9c5a17633d406190b462e90f75d48d8848ec13cf2e1093322b8R152-R155) [[5]](diffhunk://#diff-9f01b33fcc28f9c5a17633d406190b462e90f75d48d8848ec13cf2e1093322b8R172-R175)

## Summary by Sourcery

Enhancements:
- Add explicit hover colors for collapsed accordion headers for primary, secondary, light, muted, and dark variants to align visual feedback with each theme.