### PR TITLE
fix/counter-component

### DIFF
--- a/backend/static/js/counter.js
+++ b/backend/static/js/counter.js
@@ -23,6 +23,7 @@
         }
 
         const target = parseInt(counter.getAttribute('data-target'), 10);
+        const suffix = counter.getAttribute('data-suffix') || '';
 
         // Validate target number
         if (isNaN(target)) {
@@ -35,7 +36,7 @@
 
         // If user prefers reduced motion, show final value immediately
         if (prefersReducedMotion) {
-            counter.innerText = formatNumber(target);
+            counter.innerText = formatNumber(target) + suffix;
             counter.setAttribute('aria-live', 'off');
             return;
         }
@@ -56,13 +57,13 @@
             const easeProgress = progress === 1 ? 1 : 1 - Math.pow(2, -10 * progress);
 
             count = Math.floor(easeProgress * target);
-            counter.innerText = formatNumber(count);
+            counter.innerText = formatNumber(count) + suffix;
 
             if (progress < 1) {
                 requestAnimationFrame(updateCounter);
             } else {
                 // Ensure final value is exact
-                counter.innerText = formatNumber(target);
+                counter.innerText = formatNumber(target) + suffix;
                 // Stop announcing updates to screen readers
                 counter.setAttribute('aria-live', 'off');
             }

--- a/cms_theme/templates/cms_theme/cms_components/counter.html
+++ b/cms_theme/templates/cms_theme/cms_components/counter.html
@@ -6,12 +6,13 @@
 {% field "icon" IconPickerField required=False label=_("Icon") %}
 {% field "title" forms.CharField required=False label=_("Title") %}
 {% field "number" forms.IntegerField required=True label=_("Number") %}
+{% field "is_percent" forms.BooleanField required=False label=_("Is Percent") initial=False %}
 {% field "number_color" ColorChoiceField required=False label=_("Number Color") initial="dark" %}
 {% field "description" HTMLFormField required=False label=_("Description") %}
 {% field "color_style" ColorChoiceField required=False label=_("Text Color") initial="dark" %}
 {# Actual template - when rendering, declared fields are available in the context #}
 {% add_css_for_icon icon %}
-<div class="counter-component p-lg-3 rounded text-{{ color_style|default:'black' }} {{ instance.get_classes }}"{{ instance.get_attributes }}>
+<div class="text-start counter-component p-lg-3 rounded text-{{ color_style|default:'black' }} {{ instance.get_classes }}"{{ instance.get_attributes }}>
     <div class="counter-body-spacing">
         {% if icon %}
             <div class="counter-icon">
@@ -23,8 +24,9 @@
         {% endif %}
         <div class="counter-number h2 py-4 {% if number_color %}text-{{ number_color }}{% endif %}"
              data-target="{{ number }}"
-             aria-label="{% if title %}{{ title }}:{% endif %} {{ number }}"
-             role="status">0</div>
+             {% if is_percent %}data-suffix="%"{% endif %}
+             aria-label="{% if title %}{{ title }}:{% endif %} {{ number }}{% if is_percent %}%{% endif %}"
+             role="status">0{% if is_percent %}%{% endif %}</div>
         {% if description %}
             <div class="counter-description pt-1">{{ description|safe }}</div>
         {% endif %}


### PR DESCRIPTION
This pull request updates the counter component to support displaying numbers with a percent sign when appropriate. The main changes add a new boolean field to indicate if the number is a percentage and adjust both the HTML template and JavaScript to append the percent sign dynamically.

**Counter component enhancements:**

* Added a new `is_percent` boolean field to the counter component form, allowing editors to specify if the displayed number should be treated as a percentage.
* Updated the counter HTML template (`counter.html`) to:
  * Add a `data-suffix` attribute and display the percent sign if `is_percent` is set.
  * Update the `aria-label` and visible text to include `%` when applicable, improving accessibility and clarity.
  * Add the `text-start` class for improved layout.

**JavaScript logic updates:**

* Modified `counter.js` to read the new `data-suffix` attribute and append the suffix (e.g., `%`) to the counter value during animation and when reduced motion is preferred. [[1]](diffhunk://#diff-18b37e118ee5038f1a2da5b9ef4f0b8e6744ea5a030808fa260e0e100a734057R26) [[2]](diffhunk://#diff-18b37e118ee5038f1a2da5b9ef4f0b8e6744ea5a030808fa260e0e100a734057L38-R39) [[3]](diffhunk://#diff-18b37e118ee5038f1a2da5b9ef4f0b8e6744ea5a030808fa260e0e100a734057L59-R66)

## Summary by Sourcery

Enhance the counter component to support optional percentage display and propagate that suffix through the HTML template and JavaScript animation logic.

New Features:
- Add an `is_percent` boolean field to the counter component to allow editors to mark a value as a percentage.

Enhancements:
- Update the counter template to include a configurable suffix, improved text alignment, and accessible labels that reflect percent values.
- Extend the counter JavaScript to read a suffix from data attributes and include it in both animated and reduced-motion number displays.