### PR TITLE
fix: Delete template for custom form submit button

### DIFF
--- a/backend/templates/djangocms_form_builder/bootstrap5/widgets/submit.html
+++ b/backend/templates/djangocms_form_builder/bootstrap5/widgets/submit.html
@@ -1,1 +1,0 @@
-<input type="submit" value="{{ instance.config.submit_cta|default:_("Submit") }}" class="btn btn-form-secondary">


### PR DESCRIPTION
Fixes final part of #71

## Summary by Sourcery

Bug Fixes:
- Eliminate the overridden submit button template so forms fall back to the default behavior.