### PR TITLE
fix: adjust body background color and set main background

### DIFF
--- a/backend/static/scss/_class_overrides.scss
+++ b/backend/static/scss/_class_overrides.scss
@@ -89,10 +89,10 @@ body {
   font-feature-settings: 'liga' off, 'clig' off;
   -webkit-font-smoothing: antialiased;   
   -moz-osx-font-smoothing: grayscale;
-  background: $dark;
+  background-color: $dark;
 
   main {
-    background: $white;
+    background-color: $white;
   }
 }
 


### PR DESCRIPTION
This pull request makes a small change to the `backend/static/scss/_class_overrides.scss` file, updating the background colors for the `body` and `main` elements to improve visual consistency in the application.

* Visual styling update:
  - Set the `body` background to `$dark` (same as footer bg) and the `main` background to `$white` for improved contrast and readability.

## Summary by Sourcery

Update global layout backgrounds for improved visual consistency and contrast.

Enhancements:
- Set the body background to the dark theme color to align with the footer styling.
- Set the main element background to white to improve content contrast and readability.