### PR TITLE
fix: Move heading as a field into carousel plugin

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -67,7 +67,6 @@ INSTALLED_APPS = [
     "djangocms_frontend.contrib.alert",
     "djangocms_frontend.contrib.badge",
     "djangocms_frontend.contrib.card",
-    "djangocms_frontend.contrib.carousel",
     "djangocms_frontend.contrib.collapse",
     "djangocms_frontend.contrib.content",
     "djangocms_frontend.contrib.grid",

--- a/backend/static/scss/_logo_carousel.scss
+++ b/backend/static/scss/_logo_carousel.scss
@@ -1,3 +1,7 @@
+.p-carousel {
+	padding: 2px;
+}
+
 .carousel-container {
 	position: relative;
 	margin: 0 auto;

--- a/cms_theme/cms_components.py
+++ b/cms_theme/cms_components.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.conf import settings
+from django.conf import settings    
 from django.core.validators import MinValueValidator
 from django.utils.translation import gettext_lazy as _
 from djangocms_frontend.component_base import CMSFrontendComponent, Slot
@@ -7,6 +7,7 @@ from djangocms_frontend.component_pool import components
 from djangocms_frontend.contrib.icon.fields import IconPickerField
 from djangocms_frontend.contrib.image.fields import ImageFormField
 from djangocms_frontend.fields import ColoredButtonGroup, HTMLFormField
+from djangocms_frontend import settings as frontend_settings
 
 
 @components.register
@@ -113,7 +114,7 @@ class TimelineContainer(CMSFrontendComponent):
 
     divider_color = forms.ChoiceField(
         label=_("Divider line color"),
-        choices=settings.DJANGOCMS_FRONTEND_COLOR_STYLE_CHOICES,
+        choices=frontend_settings.COLOR_STYLE_CHOICES,
         required=False,
         initial="primary",
         help_text=_("Color of the vertical timeline line."),
@@ -122,7 +123,7 @@ class TimelineContainer(CMSFrontendComponent):
 
     circle_color = forms.ChoiceField(
         label=_("Circle color"),
-        choices=settings.DJANGOCMS_FRONTEND_COLOR_STYLE_CHOICES,
+        choices=frontend_settings.COLOR_STYLE_CHOICES,
         required=False,
         initial="secondary",
         help_text=_("Color of the timeline circles."),
@@ -179,7 +180,7 @@ class Footer(CMSFrontendComponent):
 
     divider_color = forms.ChoiceField(
         label=_("Divider line color"),
-        choices=settings.DJANGOCMS_FRONTEND_COLOR_STYLE_CHOICES,
+        choices=frontend_settings.COLOR_STYLE_CHOICES,
         required=False,
         initial="white",
         help_text=_("Color of the horizontal divider line."),
@@ -269,11 +270,52 @@ class LogoCarousel(CMSFrontendComponent):
         name = _("Carousel")
         render_template = "carousel/logo_carousel.html"
         allow_children = True
-        child_classes = [
-            "HeadingPlugin",
-            "CarouselItemPlugin",
-        ]
+        child_classes = ["CarouselItemPlugin"]
         mixins = ["Background", "Spacing", "Attributes"]
+        frontend_editable_fields = ("heading",)
+        fieldsets = (
+            (
+                None,
+                {
+                    "fields": (
+                        "heading",
+                        "text_color",
+                        "bg_color",
+                    )
+                },
+                _("Settings"),
+                {
+                    "fields": (
+                        "loop",
+                        "space_between_slides",
+                        "autoplay",
+                        "delay",
+                        "btn_color",
+                    )
+                },
+            ),
+        )
+
+    heading = forms.CharField(
+        label=_("Heading"),
+        required=False,
+    )
+
+    text_color = forms.ChoiceField(
+        label=_("Text color"),
+        choices=frontend_settings.EMPTY_CHOICE + frontend_settings.COLOR_STYLE_CHOICES,
+        initial=frontend_settings.EMPTY_CHOICE[0][0],
+        widget=ColoredButtonGroup(attrs={"class": "flex-wrap"}),
+        required=False,
+    )
+
+    bg_color = forms.ChoiceField(
+        label=_("Background color"),
+        choices=frontend_settings.EMPTY_CHOICE + frontend_settings.COLOR_STYLE_CHOICES,
+        initial=frontend_settings.EMPTY_CHOICE[0][0],
+        widget=ColoredButtonGroup(attrs={"class": "flex-wrap"}),
+        required=False,
+    )
 
     loop = forms.BooleanField(
         label=_("Loop Carousel"),
@@ -313,7 +355,7 @@ class LogoCarousel(CMSFrontendComponent):
 
     btn_color = forms.ChoiceField(
         label=_("Button Color"),
-        choices=settings.DJANGOCMS_FRONTEND_COLOR_STYLE_CHOICES,
+        choices=frontend_settings.COLOR_STYLE_CHOICES,
         required=False,
         initial="primary",
         widget=ColoredButtonGroup(attrs={"class": "flex-wrap"}),
@@ -360,7 +402,7 @@ class BenefitsCard(CMSFrontendComponent):
 
     text_color = forms.ChoiceField(
         label=_("Text color"),
-        choices=settings.DJANGOCMS_FRONTEND_COLOR_STYLE_CHOICES,
+        choices=frontend_settings.COLOR_STYLE_CHOICES,
         required=False,
         initial="default",
         widget=ColoredButtonGroup(attrs={"class": "flex-wrap"}),
@@ -422,7 +464,7 @@ class RelatedPeople(CMSFrontendComponent):
 
     eyebrow_text_color = forms.ChoiceField(
         label=_("Eyebrow text color"),
-        choices=settings.DJANGOCMS_FRONTEND_COLOR_STYLE_CHOICES,
+        choices=frontend_settings.COLOR_STYLE_CHOICES,
         required=False,
         initial="default",
         widget=ColoredButtonGroup(attrs={"class": "flex-wrap"}),
@@ -470,7 +512,7 @@ class PeopleCard(CMSFrontendComponent):
 
     image_accent_color = forms.ChoiceField(
         label=_("Image accent color"),
-        choices=settings.DJANGOCMS_FRONTEND_COLOR_STYLE_CHOICES,
+        choices=frontend_settings.COLOR_STYLE_CHOICES,
         required=False,
         initial="primary",
         help_text=_("Image accent color."),
@@ -491,7 +533,7 @@ class PeopleCard(CMSFrontendComponent):
 
     text_color = forms.ChoiceField(
         label=_("Text Color"),
-        choices=settings.DJANGOCMS_FRONTEND_COLOR_STYLE_CHOICES,
+        choices=frontend_settings.COLOR_STYLE_CHOICES,
         required=False,
         initial="dark",
         help_text=_("Card content text color."),
@@ -522,7 +564,7 @@ class MembershipPlans(CMSFrontendComponent):
 
     eyebrow_text_color = forms.ChoiceField(
         label=_("Text color"),
-        choices=settings.DJANGOCMS_FRONTEND_COLOR_STYLE_CHOICES,
+        choices=frontend_settings.COLOR_STYLE_CHOICES,
         required=False,
         initial="default",
         widget=ColoredButtonGroup(attrs={"class": "flex-wrap"}),
@@ -563,7 +605,7 @@ class PlanCard(CMSFrontendComponent):
 
     tier_color = forms.ChoiceField(
         label=_("Tier Color"),
-        choices=settings.DJANGOCMS_FRONTEND_COLOR_STYLE_CHOICES,
+        choices=frontend_settings.COLOR_STYLE_CHOICES,
         required=False,
         initial="default",
         widget=ColoredButtonGroup(attrs={"class": "flex-wrap"}),
@@ -622,7 +664,7 @@ class HorizontalPlanCard(CMSFrontendComponent):
 
     text_color = forms.ChoiceField(
         label=_("Text color"),
-        choices=settings.DJANGOCMS_FRONTEND_COLOR_STYLE_CHOICES,
+        choices=frontend_settings.COLOR_STYLE_CHOICES,
         required=False,
         initial="default",
         widget=ColoredButtonGroup(attrs={"class": "flex-wrap"}),
@@ -664,7 +706,7 @@ class TeaserContent(CMSFrontendComponent):
 
     text_color = forms.ChoiceField(
         label=_("Text color"),
-        choices=settings.DJANGOCMS_FRONTEND_COLOR_STYLE_CHOICES,
+        choices=frontend_settings.COLOR_STYLE_CHOICES,
         required=False,
         initial="default",
         widget=ColoredButtonGroup(attrs={"class": "flex-wrap"}),
@@ -751,7 +793,7 @@ class QuotePanelItem(CMSFrontendComponent):
 
     text_color = forms.ChoiceField(
         label=_("Text color"),
-        choices=settings.DJANGOCMS_FRONTEND_COLOR_STYLE_CHOICES,
+        choices=frontend_settings.COLOR_STYLE_CHOICES,
         required=False,
         initial="dark",
         widget=ColoredButtonGroup(attrs={"class": "flex-wrap"}),

--- a/cms_theme/templates/carousel/logo_carousel.html
+++ b/cms_theme/templates/carousel/logo_carousel.html
@@ -4,11 +4,9 @@
          {{ instance.get_attributes }}>
     {% with plugins=instance.child_plugin_instances %}
         <div class="container text-center">
-            {% for plugin in plugins %}
-                {% if plugin.plugin_type == "HeadingPlugin" %}
-                    {% render_plugin plugin %}
-                {% endif %}
-            {% endfor %}
+            {% if instance.heading %}
+                <h3 class="p-carousel text-center overline text-secondary d-inline text-{{ instance.text_color }} text-bg-{{ instance.bg_color }}">{% inline_field instance "heading" %}</h3>
+            {% endif %}
             <div class="carousel-container mx-6">
                 <div class="swiper logo-swiper-carousel logoSwiper-{{ instance.id }}"
                     data-instance-id="{{ instance.id }}"
@@ -18,9 +16,7 @@
                     data-delay="{{ instance.delay }}">
                     <div class="swiper-wrapper">
                         {% for plugin in plugins %}
-                            {% if plugin.plugin_type == "CarouselItemPlugin" %}
-                                {% render_plugin plugin %}
-                            {% endif %}
+                            {% render_plugin plugin %}
                         {% endfor %}
                     </div>
                 </div>


### PR DESCRIPTION
## Summary by Sourcery

Move carousel heading configuration into the carousel plugin instance and align color field choices with shared frontend settings.

New Features:
- Allow configuring a heading, text color, and background color directly on the carousel plugin instance.

Bug Fixes:
- Ensure carousel logo template renders only the carousel item children and no longer depends on a separate heading child plugin.

Enhancements:
- Use unified frontend color settings for various color choice fields across CMS components, including carousel controls and text colors.
- Simplify logo carousel SCSS by adding a dedicated class for the plugin heading styling.

Build:
- Remove the djangocms_frontend carousel contrib app from the Django INSTALLED_APPS configuration.

fixes #74 