### PR TITLE
feat: Add custom heading plugin with eyebrow option

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -77,7 +77,6 @@ INSTALLED_APPS = [
     "djangocms_frontend.contrib.listgroup",
     "djangocms_frontend.contrib.media",
     "djangocms_frontend.contrib.tabs",
-    "djangocms_frontend.contrib.utilities",
     "djangocms_link",
     # Specific designs for this site
     "cms_theme",

--- a/cms_theme/apps.py
+++ b/cms_theme/apps.py
@@ -4,8 +4,3 @@ from django.apps import AppConfig
 class CmsThemeConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "cms_theme"
-
-    def ready(self):
-        from djangocms_frontend.contrib.utilities.cms_plugins import HeadingPlugin
-
-        HeadingPlugin.is_local = True

--- a/cms_theme/cms_components.py
+++ b/cms_theme/cms_components.py
@@ -32,7 +32,7 @@ class Hero(CMSFrontendComponent):
         initial="",
     )
     overline = forms.CharField(
-        label=_("Overline"),
+        label=_("Eyebrow text"),
         required=False,
         initial="",
     )
@@ -801,4 +801,45 @@ class QuotePanelItem(CMSFrontendComponent):
         initial="dark",
         widget=ColoredButtonGroup(attrs={"class": "flex-wrap"}),
         help_text=_("Text color for quote item."),
+    )
+
+
+@components.register
+class Heading(CMSFrontendComponent):
+    """Heading component with text color option"""
+
+    HEADINGS = (
+        ("h1", _("Heading 1")),
+        ("h2", _("Heading 2")),
+        ("h3", _("Heading 3")),
+        ("h4", _("Heading 4")),
+        ("h5", _("Heading 5")),
+    )
+
+    class Meta:
+        name = _("Heading")
+        render_template = "heading/heading.html"
+        allow_children = True
+        child_classes = []
+        frontend_editable_fields = ("heading", "overline")
+
+    heading_level = forms.ChoiceField(
+        label=_("Heading level"),
+        choices=getattr(frontend_settings, "DJANGO_FRONTEND_HEADINGS", HEADINGS),
+        required=True,
+    )
+    overline = forms.CharField(
+        label=_("Eyebrow text"),
+        required=False,
+    )
+    heading = forms.CharField(
+        label=_("Heading"),
+        required=True,
+    )
+    heading_context = forms.ChoiceField(
+        label=_("Heading context"),
+        required=False,
+        choices=frontend_settings.EMPTY_CHOICE + frontend_settings.COLOR_STYLE_CHOICES,
+        initial=frontend_settings.EMPTY_CHOICE,
+        widget=ColoredButtonGroup(),
     )

--- a/cms_theme/templates/heading/heading.html
+++ b/cms_theme/templates/heading/heading.html
@@ -1,0 +1,4 @@
+{% load cms_tags frontend %}{% spaceless %}
+    {% if instance.overline %}<p class="overline text-{{ instance.heading_context }}">{% inline_field instance "overline" %}</p>{% endif %}
+    <{{ instance.heading_level }}{{ instance.get_attributes }} class="pb-5 mt-3 text-{{ instance.heading_context }}">{% inline_field instance "heading" %}</{{ instance.heading_level }}>
+{% endspaceless %}


### PR DESCRIPTION
## Summary by Sourcery

Introduce a custom CMS heading component with eyebrow text support and remove reliance on the generic frontend utilities heading plugin.

New Features:
- Add a custom Heading CMS component supporting configurable heading level, eyebrow text, and contextual text color.
- Add a dedicated template for rendering the new heading component with optional eyebrow text.

Enhancements:
- Rename existing overline field labels to `Eyebrow text` for clearer terminology.
- Remove registration and dependency on the shared djangocms_frontend utilities HeadingPlugin in favor of the local implementation.