### PR TITLE
fix: Rename footer slots

### DIFF
--- a/cms_theme/cms_components.py
+++ b/cms_theme/cms_components.py
@@ -163,12 +163,12 @@ class Footer(CMSFrontendComponent):
         render_template = "footer/footer.html"
         allow_children = True
         mixins = ["Background", "Spacing", "Attributes"]
-        frontend_editable_fields = ("community", "developer", "social")
+        frontend_editable_fields = ("left_label", "middle_label", "right_label")
         slots = (
-            Slot("community", _("Community Links"), child_classes=["TextLinkPlugin"]),
-            Slot("developer", _("Developer Links"), child_classes=["TextLinkPlugin"]),
-            Slot("social", _("Social Links"), child_classes=["TextLinkPlugin"]),
-            Slot("legal", _("Legal (horizontal)"), child_classes=["TextLinkPlugin", "TextPlugin"]),
+            Slot("left", _("Links left column"), child_classes=["TextLinkPlugin"]),
+            Slot("middle", _("Links middle column"), child_classes=["TextLinkPlugin"]),
+            Slot("right", _("Links right column"), child_classes=["TextLinkPlugin"]),
+            Slot("bottom", _("Bottom links"), child_classes=["TextLinkPlugin", "TextPlugin"]),
         )
         child_classes = []  # Only slots, no direct children allowed
         fieldsets = (
@@ -176,27 +176,27 @@ class Footer(CMSFrontendComponent):
                 None,
                 {
                     "fields": (
-                        ("community", "developer", "social"),
+                        ("left_label", "middle_label", "right_label"),
                         "divider_color",
                     )
                 },
             ),
         )
 
-    community = forms.CharField(
-        label=_("Community heading"),
+    left_label = forms.CharField(
+        label=_("Left column heading"),
         required=True,
         initial=_("Community"),
     )
 
-    developer = forms.CharField(
-        label=_("Developer heading"),
+    middle_label = forms.CharField(
+        label=_("Middle column heading"),
         required=True,
         initial=_("Developer"),
     )
 
-    social = forms.CharField(
-        label=_("Social heading"),
+    right_label = forms.CharField(
+        label=_("Right column heading"),
         required=True,
         initial=_("Follow us"),
     )

--- a/cms_theme/templates/footer/footer.html
+++ b/cms_theme/templates/footer/footer.html
@@ -9,7 +9,7 @@
             </div>
 
             <div class="col-12 my-lg-0 col col-md-2 py-1 my-4 py-lg-0">
-                <h2 class="text-white pb-1 overline">{% inline_field instance "community" %}</h2>
+                <h2 class="text-white pb-1 overline">{% inline_field instance "left_label" %}</h2>
                 <nav class="mt-2 list-link-container">
                     <ul class="list-unstyled m-0 d-flex list-container flex-column gap-2" role="list">
                         {% for plugin in instance|get_slot:"community" %}
@@ -22,7 +22,7 @@
             </div>
 
             <div class="col-12 my-lg-0 col col-md-2 py-1 my-4 py-lg-0">
-                <h2 class="text-white pb-1 overline">{% inline_field instance "developer" %}</h2>
+                <h2 class="text-white pb-1 overline">{% inline_field instance "middle_label" %}</h2>
                 <nav class="mt-2 list-link-container">
                     <ul class="list-unstyled m-0 d-flex list-container flex-column gap-2" role="list">
                         {% for plugin in instance|get_slot:"developer" %}
@@ -35,7 +35,7 @@
             </div>
 
             <div class="col-12 my-lg-0 col col-md-2 py-1 my-4 py-lg-0">
-                <h2 class="text-white pb-1 overline">{% inline_field instance "social" %}</h2>
+                <h2 class="text-white pb-1 overline">{% inline_field instance "right_label" %}</h2>
                 <nav class="mt-2 list-link-container">
                     <ul class="list-unstyled m-0 d-flex list-container flex-row gap-2" role="list">
                         {% for plugin in instance|get_slot:"social" %}


### PR DESCRIPTION
Move from semantic names to position-based names

## Summary by Sourcery

Rename footer component column fields and slots to use position-based names instead of semantic labels.

Enhancements:
- Update footer plugin configuration to use left/middle/right/bottom slot names and corresponding label fields.
- Align footer template headings with the new position-based label fields for the three main link columns.