### PR TITLE
chore: Add djangocms-4-utilities

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -91,6 +91,8 @@ INSTALLED_APPS = [
     "sortedm2m",
     "djangocms_file",
     "djangocms_form_builder",
+
+    "djangocms4_utilities",
 ]
 
 MIDDLEWARE = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -242,3 +242,5 @@ whitenoise==6.12.0
 # The following packages are considered to be unsafe in a requirements file:
 # pip
 # setuptools
+
+git+https://github.com/fsbraun/djangocms4-utilities#egg=djangocms4-utilities


### PR DESCRIPTION
## Summary by Sourcery

Add the djangocms4_utilities package to the project configuration.

Enhancements:
- Register djangocms4_utilities as an installed Django app.

Build:
- Declare djangocms4-utilities as a dependency in requirements.txt.