### PR TITLE
fix: Use merged PR instead of commits

### DIFF
--- a/cms_theme/cms_components.py
+++ b/cms_theme/cms_components.py
@@ -1027,6 +1027,38 @@ class CodeBlock(CMSFrontendComponent):
     )
 
 
+@components.register
+class CounterContainer(CMSFrontendComponent):
+    """Counter container component with optional heading"""
+
+    class Meta:
+        name = _("Counter Panel")
+        module = _("Sections")
+        render_template = "counter/counter_container.html"
+        allow_children = True
+        child_classes = ["CounterPlugin"]
+        mixins = ["Background", "Spacing", "Attributes"]
+
+    eyebrow_text = forms.CharField(
+        label=_("Eyebrow text"),
+        required=False,
+    )
+
+    heading = forms.CharField(
+        label=_("Heading"),
+        required=False,
+    )
+
+    text_color = forms.ChoiceField(
+        label=_("Text color"),
+        choices=frontend_settings.COLOR_STYLE_CHOICES,
+        required=False,
+        initial="default",
+        widget=ColoredButtonGroup(attrs={"class": "flex-wrap"}),
+        help_text=_("Color for eyebrow and heading text"),
+    )
+
+
 class CounterPluginMixin:
     """Plugin mixin that fetches GitHub stats for Counter components."""
 
@@ -1080,10 +1112,10 @@ class CounterPluginMixin:
             resp.raise_for_status()
             return resp.json()["total_count"]
 
-        if counter_type == "commits":
+        if counter_type == "merges":
             resp = requests.get(
-                "https://api.github.com/search/commits",
-                params={"q": f"org:{self.GITHUB_ORG} committer-date:>={since}"},
+                "https://api.github.com/search/issues",
+                params={"q": f"org:{self.GITHUB_ORG} type:pr is:merged merged:>={since}"},
                 headers={"Accept": "application/vnd.github.v3+json"},
                 timeout=10,
             )
@@ -1099,19 +1131,20 @@ class CounterPluginMixin:
         return super().render(context, instance, placeholder)
 
 
+COUNTER_TYPE_CHOICES = [
+    ("manual", _("Manual")),
+    ("stars", _("GitHub Stars")),
+    ("forks", _("GitHub Forks")),
+    ("issues_closed", _("GitHub Issues Closed (30 days)")),
+    ("merges", _("GitHub PRs Merged (30 days)")),
+]
+
+
 @components.register
 class Counter(CMSFrontendComponent):
     """Counter component with animated number display"""
 
     _plugin_mixins = [CounterPluginMixin]
-
-    COUNTER_TYPE_CHOICES = [
-        ("manual", _("Manual")),
-        ("stars", _("GitHub Stars")),
-        ("forks", _("GitHub Forks")),
-        ("issues_closed", _("GitHub Issues Closed (30 days)")),
-        ("commits", _("GitHub Commits (30 days)")),
-    ]
 
     class Meta:
         name = _("Counter")
@@ -1166,3 +1199,6 @@ class Counter(CMSFrontendComponent):
         label=_("Text Color"),
         initial="dark",
     )
+
+    def get_short_description(self):
+        return dict(COUNTER_TYPE_CHOICES).get(self.counter_type, _("Manual"))

--- a/cms_theme/templates/counter/counter_container.html
+++ b/cms_theme/templates/counter/counter_container.html
@@ -1,0 +1,24 @@
+{% load cms_tags cms_theme_tags %}
+<div class="{{ instance.get_classes }}"{{ instance.get_attributes }}>
+    <div class="container">
+        {% if instance.config.eyebrow_text or instance.config.heading %}
+            <div class="row mb-4 justify-content-center justify-content-lg-start">
+                <div class="col-12 col-md-10 col-lg-12 text-lg-start">
+                    {% if instance.config.eyebrow_text %}
+                        <h6 class="text-uppercase text-muted overline{% if instance.config.text_color %} text-{{ instance.config.text_color }}{% endif %}">{{ instance.config.eyebrow_text }}</h6>
+                    {% endif %}
+                    {% if instance.config.heading %}
+                        <h2{% if instance.config.text_color %} class="text-{{ instance.config.text_color }}"{% endif %}>{{ instance.config.heading }}</h2>
+                    {% endif %}
+                </div>
+            </div>
+        {% endif %}
+        <div class="row">
+            {% for plugin in instance.child_plugin_instances %}
+                <div class="col-lg-3 col-12 mb-lg-0 col col-md-6 mb-3">
+                    {% render_plugin plugin %}
+                </div>
+            {% endfor %}
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary by Sourcery

Replace the GitHub commit-based counter with a merged-PR-based metric and introduce a container component for grouping counters with optional headings.

New Features:
- Add a CounterContainer component to group multiple counter plugins with configurable eyebrow text, heading, and shared text color.
- Expose a short description for the Counter component based on the selected counter type.

Bug Fixes:
- Change the GitHub counter metric from commit search to merged pull requests over the last 30 days.

Enhancements:
- Centralize counter type choices in a shared constant and update labels to reflect the merged-PR metric.