### PR TITLE
fix: Adjust footer column classes for improved responsiveness

### DIFF
--- a/cms_theme/templates/footer/footer.html
+++ b/cms_theme/templates/footer/footer.html
@@ -34,7 +34,7 @@
                 </nav>
             </div>
 
-            <div class="col-12 my-lg-0 col col-md-2 py-1 my-4 py-lg-0">
+            <div class="col-12 my-xl-0 col col-xl-2 py-1 my-4 py-xl-0">
                 <h2 class="text-white pb-1 overline mb-0">{% inline_field instance "right_label" %}</h2>
                 <nav class="mt-2 list-link-container">
                     <ul class="list-unstyled m-0 d-flex list-container flex-row gap-2" role="list">

--- a/cms_theme/templates/navbar/navbar.html
+++ b/cms_theme/templates/navbar/navbar.html
@@ -30,7 +30,7 @@
     </div>
 
     {# Buttons - Desktop only (outside collapse for grid layout) #}
-    <div class="d-none d-xl-flex gap-3 ms-auto">
+    <div class="d-none d-xl-flex flex-column flex-xxl-row gap-3 ms-auto">
       {% for plugin in instance.child_plugin_instances %}
           {% if plugin.plugin_type == "TextLinkPlugin" %}
               {% render_plugin plugin %}


### PR DESCRIPTION
This pull request makes a minor adjustment to the grid layout in the `footer.html` template, updating the column sizing and spacing classes to use `xl` (extra large) breakpoints instead of `lg` (large) for improved responsiveness.

- Layout adjustment:
  * Changed the column and margin classes from `col-md-2`/`my-lg-0`/`py-lg-0` to `col-xl-2`/`my-xl-0`/`py-xl-0` to better target extra large screens in the footer section (`cms_theme/templates/footer/footer.html`).

## Summary by Sourcery

Enhancements:
- Update footer column and spacing classes to use extra-large (xl) breakpoints instead of large (lg) for the right-hand column.