### PR TITLE
feat: Add body content to hero section and adjust hero counter styling

### DIFF
--- a/cms_theme/templates/hero/hero.html
+++ b/cms_theme/templates/hero/hero.html
@@ -11,9 +11,9 @@
                 <div class="row">
                     <div class="col-12 col-lg-11">
                         <h1 class="mt-2 pb-4 mb-0">{% inline_field instance "heading"  %}</h1>
+                        {% if instance.body %}<div class="fs-5 pb-2 mb-0">{% inline_field instance "body" "" "safe" %}</div>{% endif %}
                     </div>
                 </div>
-                {% if instance.body %}<div class="fs-5 pb-2 mb-0">{% inline_field instance "body" "" "safe" %}</div>{% endif %}
                 <div class="mt-4">
                     {% for plugin in instance|get_slot:"links" %}
                     {% render_plugin plugin %}
@@ -34,7 +34,7 @@
                     {# Second and third plugins: overlay items #}
                     <div class="hero-counters">
                         {% for plugin in instance|get_slot:"satellites" %}
-                            <div class="hero-counter hero-counter-{{ forloop.counter }}">
+                            <div class="hero-counter hero-counter-{{ forloop.counter }} {% if instance.config.main_image_url and forloop.counter == 1 %} ms-lg-3 {% endif %}">
                                 {% render_plugin plugin %}
                             </div>
                         {% endfor %}


### PR DESCRIPTION
This pull request makes minor adjustments to the `hero.html` template to improve the layout and conditional rendering of certain elements. The changes help ensure that the body text appears in the correct location and that the first "satellite" counter receives additional styling when a main image is present.

Layout and conditional rendering improvements:

* Moved the conditional rendering of the `body` field so that it appears inside the main content column, ensuring better alignment with the heading.
* Added a conditional CSS class (`ms-lg-3`) to the first "satellite" counter when a main image URL is present in the configuration, improving spacing in that scenario.

<img width="1424" height="880" alt="image" src="https://github.com/user-attachments/assets/be4b051f-3a96-4538-aaef-d042faf5d282" />
