### PR TITLE
feat: Add option to show pypi downloads (last month and total)

### DIFF
--- a/cms_theme/cms_components.py
+++ b/cms_theme/cms_components.py
@@ -1193,7 +1193,7 @@ class CounterPluginMixin:
             )
             resp.raise_for_status()
             data = resp.json()
-            return data["stargazers_count" if counter_type == "stars" else "forks_count"]
+            return data.get("stargazers_count" if counter_type == "stars" else "forks_count")
 
         since = (datetime.now(tz=timezone.utc) - timedelta(days=30)).strftime("%Y-%m-%d")
 

--- a/cms_theme/cms_components.py
+++ b/cms_theme/cms_components.py
@@ -1178,7 +1178,7 @@ class CounterPluginMixin:
             timeout=10,
         )
         resp.raise_for_status()
-        return resp.json()["data"]["last_month"]
+        return resp.json().get("data", {}).get("last_month")
 
     def _fetch_github_stat(self, counter_type):
         from datetime import datetime, timedelta, timezone

--- a/cms_theme/cms_components.py
+++ b/cms_theme/cms_components.py
@@ -1131,18 +1131,19 @@ class CounterContainer(CMSFrontendComponent):
 
 
 class CounterPluginMixin:
-    """Plugin mixin that fetches GitHub stats for Counter components."""
+    """Plugin mixin that fetches GitHub/PyPI stats for Counter components."""
 
     GITHUB_REPO = "django-cms/django-cms"
     GITHUB_ORG = "django-cms"
+    PYPI_PACKAGE = "django-cms"
     CACHE_TIMEOUT = 86400  # 24 hours
 
-    def _get_github_number(self, counter_type):
+    def _get_counter_number(self, counter_type):
         import logging
 
         from django.core.cache import cache
 
-        cache_key = f"counter_github_{counter_type}"
+        cache_key = f"counter_{counter_type}"
         cached = cache.get(cache_key)
         if cached is not None:
             return cached
@@ -1150,11 +1151,34 @@ class CounterPluginMixin:
         logger = logging.getLogger(__name__)
         number = 0
         try:
-            number = self._fetch_github_stat(counter_type)
+            if counter_type in ("pypi_downloads", "pypi_downloads_total"):
+                number = self._fetch_pypi_downloads(counter_type)
+            else:
+                number = self._fetch_github_stat(counter_type)
         except Exception:
-            logger.exception("Failed to fetch GitHub stat for %s", counter_type)
+            logger.exception("Failed to fetch stat for %s", counter_type)
         cache.set(cache_key, number, self.CACHE_TIMEOUT)
         return number
+
+    def _fetch_pypi_downloads(self, counter_type):
+        import requests
+
+        if counter_type == "pypi_downloads_total":
+            resp = requests.get(
+                f"https://api.pepy.tech/api/v2/projects/{self.PYPI_PACKAGE}",
+                headers={"Accept": "application/json"},
+                timeout=10,
+            )
+            resp.raise_for_status()
+            return resp.json()["total_downloads"]
+
+        resp = requests.get(
+            f"https://pypistats.org/api/packages/{self.PYPI_PACKAGE}/recent",
+            headers={"Accept": "application/json"},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        return resp.json()["data"]["last_month"]
 
     def _fetch_github_stat(self, counter_type):
         from datetime import datetime, timedelta, timezone
@@ -1198,7 +1222,7 @@ class CounterPluginMixin:
     def render(self, context, instance, placeholder):
         counter_type = instance.config.get("counter_type", "manual")
         if counter_type != "manual":
-            instance.config["number"] = self._get_github_number(counter_type)
+            instance.config["number"] = self._get_counter_number(counter_type)
         return super().render(context, instance, placeholder)
 
 
@@ -1208,6 +1232,8 @@ COUNTER_TYPE_CHOICES = [
     ("forks", _("GitHub Forks")),
     ("issues_closed", _("GitHub Issues Closed (30 days)")),
     ("merges", _("GitHub PRs Merged (30 days)")),
+    ("pypi_downloads", _("PyPI Downloads (last month)")),
+    ("pypi_downloads_total", _("PyPI Downloads (total)")),
 ]
 
 

--- a/cms_theme/cms_components.py
+++ b/cms_theme/cms_components.py
@@ -1,3 +1,5 @@
+import logging
+
 from django import forms
 from django.conf import settings
 from django.core.exceptions import ValidationError
@@ -17,6 +19,10 @@ from djangocms_frontend.fields import (
     IconGroup,
 )
 from djangocms_frontend.helpers import first_choice
+
+
+# Common logger
+logger = logging.getLogger(__name__)
 
 
 @components.register
@@ -1139,8 +1145,6 @@ class CounterPluginMixin:
     CACHE_TIMEOUT = 86400  # 24 hours
 
     def _get_counter_number(self, counter_type):
-        import logging
-
         from django.core.cache import cache
 
         cache_key = f"counter_{counter_type}"
@@ -1148,7 +1152,6 @@ class CounterPluginMixin:
         if cached is not None:
             return cached
 
-        logger = logging.getLogger(__name__)
         number = 0
         try:
             if counter_type in ("pypi_downloads", "pypi_downloads_total"):

--- a/cms_theme/templates/hero/hero.html
+++ b/cms_theme/templates/hero/hero.html
@@ -23,9 +23,9 @@
 
             <div class="col-lg-6 hero-content-right position-relative">
                 {% if instance.config.main_image_url or instance.main_image %}
-                    <div class="hero-main-image mt-5 mt-lg-0"{% if hero_clip %} style="clip-path: url(#hero-clip-{{ instance.pk }})"{% endif %}>
-                        {% if instance.config.main_image_url %}
-                            {% plugin "image" external_picture=instance.config.main_image_url template=instance.main_image_template %}{% endplugin %}
+                    <div class="hero-main-image mt-5 mt-lg-0">
+                        {% if instance.main_image_url %}
+                            {% plugin "image" external_picture=instance.main_image_url template=instance.main_image_template %}{% endplugin %}
                         {% else %}
                             {% plugin "image" picture=instance.main_image template=instance.main_image_template %}{% endplugin %}
                         {% endif %}


### PR DESCRIPTION
## Summary by Sourcery

Add support for displaying PyPI download statistics alongside existing GitHub counters and adjust the hero image template configuration accordingly.

New Features:
- Expose new counter types for PyPI downloads over the last month and in total, backed by external API calls.

Enhancements:
- Generalize the counter fetching logic to handle both GitHub statistics and PyPI download metrics using shared caching.
- Simplify hero template image rendering by using the instance’s direct main image URL field instead of the config-based value.