### PR TITLE
feat: remove unused plugins

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -67,7 +67,6 @@ INSTALLED_APPS = [
     "djangocms_frontend.contrib.alert",
     "djangocms_frontend.contrib.badge",
     "djangocms_frontend.contrib.card",
-    "djangocms_frontend.contrib.collapse",
     "djangocms_frontend.contrib.content",
     "djangocms_frontend.contrib.grid",
     "djangocms_frontend.contrib.icon",
@@ -75,7 +74,6 @@ INSTALLED_APPS = [
     "djangocms_frontend.contrib.link",
     "djangocms_frontend.contrib.listgroup",
     "djangocms_frontend.contrib.media",
-    "djangocms_frontend.contrib.tabs",
     "djangocms_link",
     # Specific designs for this site
     "cms_theme",
@@ -556,6 +554,19 @@ DJANGOCMS_PICTURE_TEMPLATES = [
 CMS_COMPONENT_PLUGINS = [
     "ImagePlugin",
 ]
+
+CMS_PLACEHOLDER_CONFIG = {
+    "content": {
+        "exclude_plugins": [
+            "FooterPlugin", 
+            "CardPlugin", 
+            "CardLayoutPlugin", 
+            "RowPlugin", 
+            "ContainerPlugin", 
+            "FigurePlugin",
+        ]
+    }
+}
 
 if not DEBUG:
     import sentry_sdk

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -65,7 +65,6 @@ INSTALLED_APPS = [
     # optional django CMS frontend modules
     "djangocms_frontend",
     "djangocms_frontend.contrib.alert",
-    "djangocms_frontend.contrib.badge",
     "djangocms_frontend.contrib.card",
     "djangocms_frontend.contrib.content",
     "djangocms_frontend.contrib.grid",
@@ -555,14 +554,14 @@ CMS_COMPONENT_PLUGINS = [
     "ImagePlugin",
 ]
 
-CMS_PLACEHOLDER_CONFIG = {
+CMS_PLACEHOLDER_CONF = {
     "content": {
-        "exclude_plugins": [
-            "FooterPlugin", 
-            "CardPlugin", 
-            "CardLayoutPlugin", 
-            "RowPlugin", 
-            "ContainerPlugin", 
+        "excluded_plugins": [
+            "FooterPlugin",
+            "CardPlugin",
+            "CardLayoutPlugin",
+            "RowPlugin",
+            "ContainerPlugin",
             "FigurePlugin",
         ]
     }

--- a/cms_theme/apps.py
+++ b/cms_theme/apps.py
@@ -11,4 +11,8 @@ class CmsThemeConfig(AppConfig):
         code_plugin = plugin_pool.get_plugin("CodeBlockPlugin")
         if code_plugin:
             code_plugin.change_form_template = "code_block/admin/code_block.html"
-            
+        
+        from djangocms_frontend.contrib.grid.cms_plugins import GridColumnPlugin
+
+        GridColumnPlugin.is_slot = True
+        

--- a/cms_theme/migrations/0009_benefitscards_linkcontainer_delete_benefitspanel_and_more.py
+++ b/cms_theme/migrations/0009_benefitscards_linkcontainer_delete_benefitspanel_and_more.py
@@ -6,16 +6,16 @@ from django.db import migrations
 def rename_plugin(apps, schema_editor):
     CMSPlugin = apps.get_model("cms", "CMSPlugin")
     CMSPlugin.objects.filter(
-        plugin_type="BenefitsPanel",
-    ).update(plugin_type="BenefitsCards")
+        plugin_type="BenefitsPanelPlugin",
+    ).update(plugin_type="BenefitsCardsPlugin")
 
 
 
 def reverse_rename(apps, schema_editor):
     CMSPlugin = apps.get_model("cms", "CMSPlugin")
     CMSPlugin.objects.filter(
-        plugin_type="BenefitsCards",
-    ).update(plugin_type="BenefitsPanel")
+        plugin_type="BenefitsCardsPlugin",
+    ).update(plugin_type="BenefitsPanelPlugin")
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
## Summary by Sourcery

Clean up Django CMS plugin configuration and align custom plugin behavior with frontend grid support.

Enhancements:
- Remove unused Django CMS frontend contrib plugins from the project configuration.
- Configure the main content placeholder to exclude footer, card, layout, row, container, and figure-related plugins.
- Correct historical plugin type names in a migration to match the current plugin class identifiers.
- Mark the frontend grid column plugin as a slot to support layout composition in the theme app.