### PR TITLE
feat: Add accent shapes to profile images in author cards

### DIFF
--- a/backend/static/scss/_related_people.scss
+++ b/backend/static/scss/_related_people.scss
@@ -72,27 +72,63 @@
 .profile-wrapper {
   position: relative;
   width: 100%;
-  max-width: 250px;
-  margin: 0 auto;
 
   .shape-tl, .shape-br {
     position: absolute;
-    border-radius: 10px;
+    border-radius: 15.45px;
     z-index: 0;
   }
 
   .shape-tl {
-    width: 50px;
-    height: 80px;
+    width: 160px;
+    height: 101px;
     top: 25px;
-    left: -25px;
+    left: 0;
   }
 
   .shape-br {
-    width: 150px;
-    height: 160px;
+    width: 160px;
+    height: 154px;
     bottom: -30px;
-    right: -40px;
+    right: 0;
+  }
+
+  img {
+    position: relative;
+    z-index: 1;
+    display: block;
+    width: 100%;
+    max-width: 260px;
+    height: 255px;
+    object-fit: cover;
+    border-radius: 15.45px;
+    margin: 0 auto;
+  }
+}
+
+.profile-wrapper-sm {
+  position: relative;
+  width: 101px;
+  flex-shrink: 0;
+
+  .shape-tl, .shape-br {
+    position: absolute;
+    border-radius: 15.45px;
+    z-index: 0;
+  }
+
+  .shape-tl {
+    width: 22px;
+    height: 38px;
+    top: 10px;
+    left: -11px;
+  }
+
+  .shape-br {
+    width: 52px;
+    height: 60px;
+    bottom: -12px;
+    right: -16px;
   }
 
   img {
@@ -102,6 +138,7 @@
     height: auto;
     aspect-ratio: 1 / 1;
     object-fit: cover;
+    border-radius: 15.45px;
   }
 }
 

--- a/backend/templates/blog/includes/card_author.html
+++ b/backend/templates/blog/includes/card_author.html
@@ -13,14 +13,24 @@
             <div class="card-text text-secondary pt-3 pb-2">
                 {% render_model post_content "abstract" "" "" "truncatewords_html:20|safe"  %}
             </div>
-            <div class="d-flex flex-row gap-4 mt-auto pt-4">
+            <div class="d-flex flex-row mt-auto pt-4" style="gap: 34px;">
                 {% with post_content.author.author_profile as profile %}
                 {% if profile %}
-                <div>
                     {% if profile.photo %}
-                        <img src="{{ profile.photo.url }}" alt="{{ profile.name }}" width="135" height="114"/>
+                        {% if profile.has_photo_accents %}
+                            <div>
+                                <div class="profile-wrapper-sm">
+                                    <div class="shape-tl bg-primary"></div>
+                                    <div class="shape-br bg-primary"></div>
+                                    <img src="{{ profile.photo.url }}" alt="{{ profile.name }}" class="{% if profile.has_drop_shadow %}shadow-sm{% endif %}"/>
+                                </div>
+                            </div>
+                        {% else %}
+                            <div class="d-flex align-items-center">
+                                <img src="{{ profile.photo.url }}" alt="{{ profile.name }}" width="135"/>
+                            </div>
+                        {% endif %}
                     {% endif %}
-                </div>
                 <div class="py-2">
                     <h4 class="pt-1 pb-2">{{ profile.name }}</h4>
                     {% if profile.role %}

--- a/cms_theme/templates/related_people/person_card.html
+++ b/cms_theme/templates/related_people/person_card.html
@@ -2,7 +2,7 @@
 <div class="{{ instance.get_classes }} card related-people-card p-4 shadow-lg"
      {{ instance.get_attributes }}>
         {% if instance.image_accent %}
-            <div class="profile-wrapper mb-4 mt-3">
+            <div class="profile-wrapper mb-4">
                 <div class="position-absolute {% if instance.image_accent_color %}bg-{{ instance.image_accent_color }}{% endif %} shape-tl z-0">
                 </div>
                 <div class="position-absolute {% if instance.image_accent_color %}bg-{{ instance.image_accent_color }}{% endif %} shape-br z-0">


### PR DESCRIPTION
This pull request updates the styling and markup for profile images in the related people and author card components. The main focus is on improving the appearance of profile images by adjusting their layout, adding accent shapes, and ensuring consistent border radii and object-fit properties. The changes introduce a new `.profile-wrapper-sm` class for smaller profile images and enhance the handling of image accents in templates.

**Styling and layout improvements:**

* Updated `.profile-wrapper` in `_related_people.scss` to increase the size and border radius of accent shapes, and added specific styles for the profile image to ensure proper sizing, centering, and rounded corners.
* Added a new `.profile-wrapper-sm` class in `_related_people.scss` for smaller profile images, with its own shape sizes and positioning for accent elements.
* Ensured all profile images have a consistent border radius and use `object-fit: cover` for better image presentation.

**Template and markup enhancements:**

* Updated `card_author.html` to conditionally wrap author images with the new `.profile-wrapper-sm` and accent shapes when `has_photo_accents` is true, and added logic for drop shadows via a class.
* Adjusted `person_card.html` to remove unnecessary top margin from `.profile-wrapper` for a more balanced card layout.

## Summary by Sourcery

Update profile image wrappers and accents for author and related people cards to improve visual consistency and layout.

New Features:
- Introduce a small profile wrapper variant with accent shapes for compact author images.

Enhancements:
- Adjust related people profile wrapper dimensions, border radii, and image styling for better presentation.
- Standardize profile image border radius and object-fit behavior across related people and author cards.
- Refine author card layout spacing and handling of optional photo accents and drop shadows.
- Tweak related people person card image container margins for a more balanced layout.

<img width="478" height="373" alt="image" src="https://github.com/user-attachments/assets/778e47bf-756b-4e1e-a61f-095bfccff1c5" />

<img width="204" height="223" alt="image" src="https://github.com/user-attachments/assets/d18d8f9b-b53e-4d9d-8c5b-cf87410f7de8" />

 