### PR TITLE
Fix/video trying to play a video on safari gives an error

### DIFF
--- a/backend/static/js/video_modal.js
+++ b/backend/static/js/video_modal.js
@@ -18,9 +18,19 @@
         return url;
     }
 
+    // Safari ITP blocks third-party requests to youtube.com (stats/log endpoints),
+    // causing the embed player to fail with error 153. youtube-nocookie.com is
+    // exempted because it doesn't set cookies until the user interacts.
+    function toNocookieEmbed(url) {
+        if (!url) return url;
+        return url
+            .replace('://www.youtube.com/embed/', '://www.youtube-nocookie.com/embed/')
+            .replace('://youtube.com/embed/', '://www.youtube-nocookie.com/embed/');
+    }
+
     function openFullscreenEmbed(src) {
         var iframe = document.createElement('iframe');
-        var fullSrc = ensureHttps(src);
+        var fullSrc = toNocookieEmbed(ensureHttps(src));
         fullSrc += (fullSrc.indexOf('?') === -1 ? '?autoplay=1' : '&autoplay=1');
         iframe.src = fullSrc;
         iframe.allow = 'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share';
@@ -96,7 +106,7 @@
 
             modal.addEventListener('shown.bs.modal', function() {
                 if (media.type === 'iframe') {
-                    media.el.src = ensureHttps(media.src);
+                    media.el.src = toNocookieEmbed(ensureHttps(media.src));
                 } else {
                     media.el.src = media.src;
                     media.el.play();

--- a/backend/templates/djangocms_video/default/video_player.html
+++ b/backend/templates/djangocms_video/default/video_player.html
@@ -1,10 +1,10 @@
-{% load i18n cms_tags %}
+{% load i18n cms_tags cms_theme_tags %}
 
 
 <div class="djangocms-video-plugin">
     {% if instance.embed_link %}
         {# show iframe if embed_link is provided #}
-        <iframe src="{{ instance.embed_link_with_parameters }}" 
+        <iframe src="{{ instance.embed_link_with_parameters|to_nocookie_embed }}"
             {{ instance.attributes_str }} 
             allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
             referrerpolicy="strict-origin-when-cross-origin"

--- a/backend/templates/djangocms_video/default/video_player.html
+++ b/backend/templates/djangocms_video/default/video_player.html
@@ -1,0 +1,38 @@
+{% load i18n cms_tags %}
+
+
+<div class="djangocms-video-plugin">
+    {% if instance.embed_link %}
+        {# show iframe if embed_link is provided #}
+        <iframe src="{{ instance.embed_link_with_parameters }}" 
+            {{ instance.attributes_str }} 
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            referrerpolicy="strict-origin-when-cross-origin"
+            frameborder="0" 
+            allowfullscreen="true">
+        </iframe>
+        {% with disabled=instance.embed_link %}
+            {% for plugin in instance.child_plugin_instances %}
+                {% render_plugin plugin %}
+            {% endfor %}
+        {% endwith %}
+    {% else %}
+        {# render <source> or <track> plugins #}
+        <video controls {{ instance.attributes_str }}
+            {% if instance.poster %} poster="{{ instance.poster.url }}"{% endif %}>
+            {% for plugin in instance.child_plugin_instances %}
+                {% render_plugin plugin %}
+            {% endfor %}
+            {% trans "Your browser doesn't support this video format." %}
+        </video>
+    {% endif %}
+
+    {% comment %}
+        # Available variables:
+        {{ instance.template }}
+        {{ instance.label }}
+        {{ instance.embed_link }}
+        {{ instance.poster }}
+        {{ instance.attributes_str }}
+    {% endcomment %}
+</div>

--- a/cms_theme/templates/cms_theme/base.html
+++ b/cms_theme/templates/cms_theme/base.html
@@ -5,6 +5,7 @@
         <meta charset="utf-8"/>
         <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
         <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no"/>
+        <meta name="referrer" content="strict-origin-when-cross-origin" />
         {% block meta %}
             <meta name="description" content="{% page_attribute meta_description %}"/>
             <meta property="og:type" content="website"/>

--- a/cms_theme/templates/two_column/slots/media.html
+++ b/cms_theme/templates/two_column/slots/media.html
@@ -26,7 +26,7 @@
                                 <button type="button" class="btn-close btn-close-white position-absolute top-0 end-0 m-3 z-3" data-bs-dismiss="modal" aria-label="Close"></button>
                                 <div class="ratio ratio-16x9">
                                     {% if video_plugin.0.embed_link %}
-                                        <iframe data-src="{{ video_plugin.0.embed_link }}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen referrerpolicy="no-referrer-when-downgrade"></iframe>
+                                        <iframe data-src="{{ video_plugin.0.embed_link|to_nocookie_embed }}" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen referrerpolicy="no-referrer-when-downgrade"></iframe>
                                     {% elif video_sources %}
                                         <video data-src="{{ video_sources.0.source_file.url }}" controls playsinline preload="none"{% if video_plugin.0.poster %} poster="{{ video_plugin.0.poster.url }}"{% endif %}></video>
                                     {% endif %}

--- a/cms_theme/templatetags/cms_theme_tags.py
+++ b/cms_theme/templatetags/cms_theme_tags.py
@@ -65,6 +65,22 @@ def get_clip_path_data(clip_path_id):
     return None
 
 @register.filter
+def to_nocookie_embed(url):
+    """Rewrite YouTube embed URLs to the privacy-enhanced youtube-nocookie.com domain.
+
+    Why: Safari's Intelligent Tracking Prevention blocks third-party requests
+    to youtube.com (stats/log endpoints), causing the embedded player to fail
+    with error 153. youtube-nocookie.com is exempted because it doesn't set
+    cookies until the user interacts with the player.
+    """
+    if not url:
+        return url
+    return url.replace("://www.youtube.com/embed/", "://www.youtube-nocookie.com/embed/").replace(
+        "://youtube.com/embed/", "://www.youtube-nocookie.com/embed/"
+    )
+
+
+@register.filter
 def get_slot(instance, slot_name):
     """Get plugins for a specific slot
     Usage: plugins|get_slot:"community"


### PR DESCRIPTION
This pull request improves YouTube embed privacy and compatibility across the site by consistently rewriting YouTube embed URLs to use the privacy-enhanced `youtube-nocookie.com` domain. This change addresses Safari's Intelligent Tracking Prevention (ITP) issues, preventing playback errors and reducing third-party tracking. The update is implemented in both the JavaScript modal logic and Django templates, and introduces a reusable template filter for this purpose.

**YouTube embed privacy and compatibility:**

* Added a `to_nocookie_embed` template filter in `cms_theme_tags.py` to rewrite YouTube embed URLs to `youtube-nocookie.com`, preventing Safari ITP errors and enhancing privacy.
* Updated all relevant Django templates (`video_player.html`, `media.html`) to use the new filter, ensuring all embedded YouTube videos use the privacy-enhanced domain. [[1]](diffhunk://#diff-259a59ccbb4cd0bf3de7dba3e32c26234d8002702c56dd94624425bb16b27432R1-R38) [[2]](diffhunk://#diff-767c7304f0eb55d2058fb5e29914c23302d2272d897547d5aae33a7647d69fc1L29-R29)

**Frontend JavaScript updates:**

* Updated `video_modal.js` to rewrite YouTube embed URLs to `youtube-nocookie.com` before loading them in iframes, both for fullscreen and modal video playback. [[1]](diffhunk://#diff-c529a64d406b2b13de5d8bd3639746bf7b40cf68108901e6aace0be0eaad1268R21-R33) [[2]](diffhunk://#diff-c529a64d406b2b13de5d8bd3639746bf7b40cf68108901e6aace0be0eaad1268L99-R109)

**Site-wide privacy enhancements:**

* Added a `referrer` meta tag with `strict-origin-when-cross-origin` in the site base template for improved privacy.

## Summary by Sourcery

Ensure YouTube video embeds use the privacy-enhanced domain and improve cross-origin privacy defaults.

New Features:
- Introduce a reusable to_nocookie_embed template filter to rewrite YouTube embed URLs to youtube-nocookie.com.
- Add a custom djangocms_video video_player template that serves YouTube embeds via the privacy-enhanced domain.

Bug Fixes:
- Fix Safari playback errors for embedded YouTube videos by avoiding blocked youtube.com tracking endpoints in both templates and JavaScript modals.

Enhancements:
- Update JavaScript video modal logic to normalize YouTube embed URLs to youtube-nocookie.com for fullscreen and modal playback.
- Apply a strict-origin-when-cross-origin referrer policy site-wide to reduce cross-site referrer leakage.