### PR TITLE
fix: Restrict root plugin selection to sections

### DIFF
--- a/backend/settings.py
+++ b/backend/settings.py
@@ -60,12 +60,8 @@ INSTALLED_APPS = [
     "djangocms_alias",
     "parler",
     # Specific designs for this site
-    "cms_theme",
     "djangocms_video",
     "djangocms_ecosystem",
-    # the default text editor - optional, but used in most projects
-    "djangocms_text",
-    "djangocms_markdown",
     # optional django CMS frontend modules
     "djangocms_frontend",
     "djangocms_frontend.contrib.alert",
@@ -87,6 +83,11 @@ INSTALLED_APPS = [
     "sortedm2m",
     "djangocms_file",
     "djangocms_form_builder",
+    # Last, to allow modifying third-party plugins
+    "cms_theme",
+    # the default text editor
+    "djangocms_text",
+    "djangocms_markdown",
 
     "djangocms4_utilities",
 ]
@@ -299,7 +300,6 @@ if DEBUG:
 
 # Design settings
 STORIES_PLUGIN_TEMPLATE_FOLDERS = (
-    ("plugins", _("Default")),
     ("cards", _("Cards Image on Top")),
     ("cards_author", _("Cards with Author")),
     ("events", _("Events")),

--- a/cms_theme/apps.py
+++ b/cms_theme/apps.py
@@ -5,6 +5,8 @@ class CmsThemeConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "cms_theme"
 
+    root_plugins = ("TextPlugin", "MDTextPlugin", "Alias")
+
     def ready(self) -> None:
         from cms.plugin_pool import plugin_pool
         from djangocms_frontend.contrib.grid.cms_plugins import GridColumnPlugin
@@ -13,5 +15,5 @@ class CmsThemeConfig(AppConfig):
 
         plugin_pool.discover_plugins()
         for plugin_type, plugin in plugin_pool.plugins.items():
-            if plugin_type != "TextPlugin" and str(plugin.module) != "Sections" and plugin.allowed_models is None:
+            if plugin_type not in self.root_plugins and str(plugin.module) != "Sections" and plugin.allowed_models is None:
                 plugin.require_parent = True

--- a/cms_theme/apps.py
+++ b/cms_theme/apps.py
@@ -6,6 +6,12 @@ class CmsThemeConfig(AppConfig):
     name = "cms_theme"
 
     def ready(self) -> None:
+        from cms.plugin_pool import plugin_pool
         from djangocms_frontend.contrib.grid.cms_plugins import GridColumnPlugin
 
         GridColumnPlugin.is_slot = True
+
+        plugin_pool.discover_plugins()
+        for plugin_type, plugin in plugin_pool.plugins.items():
+            if plugin_type != "TextPlugin" and str(plugin.module) != "Sections" and plugin.allowed_models is None:
+                plugin.require_parent = True

--- a/cms_theme/cms_components.py
+++ b/cms_theme/cms_components.py
@@ -244,6 +244,7 @@ class MegaMenu(CMSFrontendComponent):
     class Meta:
         name = _("Mega Menu")
         render_template = "megamenu/menu.html"
+        allowed_models = ["djangocms_alias.aliascontent"]
         slots = (
             Slot("left", _("Left column"), child_classes=["TextPlugin", "TextLinkPlugin"]),
             Slot("links", _("Links (middle)")),
@@ -265,6 +266,7 @@ class Footer(CMSFrontendComponent):
     class Meta:
         name = _("Footer")
         render_template = "footer/footer.html"
+        allowed_models = ["djangocms_alias.aliascontent"]
         allow_children = True
         mixins = ["Background", "Spacing", "Attributes"]
         frontend_editable_fields = ("left_label", "middle_label", "right_label")
@@ -904,8 +906,8 @@ class TwoColumn(CMSFrontendComponent):
         slots = [
             Slot("content", _("Content"), render_template="two_column/slots/content.html"),
             Slot(
-                "media", 
-                _("Media"), 
+                "media",
+                _("Media"),
                 render_template="two_column/slots/media.html",
                 child_classes=[
                     "ImagePlugin",

--- a/cms_theme/cms_components.py
+++ b/cms_theme/cms_components.py
@@ -244,7 +244,7 @@ class MegaMenu(CMSFrontendComponent):
     class Meta:
         name = _("Mega Menu")
         render_template = "megamenu/menu.html"
-        allowed_models = ["djangocms_alias.aliascontent"]
+        allowed_models = ["djangocms_alias.AliasContent"]
         slots = (
             Slot("left", _("Left column"), child_classes=["TextPlugin", "TextLinkPlugin"]),
             Slot("links", _("Links (middle)")),
@@ -266,7 +266,7 @@ class Footer(CMSFrontendComponent):
     class Meta:
         name = _("Footer")
         render_template = "footer/footer.html"
-        allowed_models = ["djangocms_alias.aliascontent"]
+        allowed_models = ["djangocms_alias.AliasContent"]
         allow_children = True
         mixins = ["Background", "Spacing", "Attributes"]
         frontend_editable_fields = ("left_label", "middle_label", "right_label")

--- a/cms_theme/templates/cms_theme/cms_components/carousel_item.html
+++ b/cms_theme/templates/cms_theme/cms_components/carousel_item.html
@@ -7,23 +7,23 @@
 <div class="swiper-slide logo-item{% if grayscale %} grayscale{% endif %}">
     {% with image=logo|get_related_object %}
         {% thumbnail image "400x0" crop subject_location=image.subject_location as sm %}
-            {% thumbnail image "800x0" crop subject_location=image.subject_location as md %}
-                {% thumbnail image "1200x0" crop subject_location=image.subject_location as lg %}
-                    {% if logo_link %}
-                        <a href="{{ logo_link|to_url }}"
-                           target="_blank"
-                           rel="noopener noreferrer">
-                        {% endif %}
-                        <img src="{{ md.url }}"
-                             srcset="{{ sm.url }} 400w,
-                                     {{ md.url }} 800w,
-                                     {{ lg.url }} 1200w"
-                             sizes="(max-width: 768px) 90vw,
-                                    (max-width: 1200px) 70vw,
-                                    1200px"
-                             alt="{{ image.alt }}"
-                             title="{{ image.title }}"
-                             loading="lazy">
-                        {% if logo_link %}</a>{% endif %}
-                {% endwith %}
-            </div>
+        {% thumbnail image "800x0" crop subject_location=image.subject_location as md %}
+        {% thumbnail image "1200x0" crop subject_location=image.subject_location as lg %}
+            {% if logo_link %}
+                <a href="{{ logo_link|to_url }}"
+                    target="_blank"
+                    rel="noopener noreferrer">
+            {% endif %}
+            <img src="{{ md.url }}"
+                    srcset="{{ sm.url }} 400w,
+                            {{ md.url }} 800w,
+                            {{ lg.url }} 1200w"
+                    sizes="(max-width: 768px) 90vw,
+                        (max-width: 1200px) 70vw,
+                        1200px"
+                    alt="{{ image.alt }}"
+                    title="{{ image.title }}"
+                    loading="lazy">
+            {% if logo_link %}</a>{% endif %}
+    {% endwith %}
+</div>


### PR DESCRIPTION
## Summary by Sourcery

Restrict which CMS plugins can be used at the root level and tighten integration of site-specific layout components with alias content and frontend grid behavior.

Bug Fixes:
- Set most CMS plugins to require a parent so only section-like containers and text are available at the root level, preventing invalid page structures.

Enhancements:
- Mark the frontend grid column plugin as a slot and ensure plugins are discovered and patched at app startup.
- Limit the MegaMenu and Footer components to be used only with alias content models.
- Adjust installed app ordering so the theme and text editor apps load after core CMS plugins, and simplify stories plugin template options.