### PR TITLE
fix: Update CTA markup

### DIFF
--- a/cms_theme/cms_components.py
+++ b/cms_theme/cms_components.py
@@ -366,6 +366,7 @@ class CTAPanel(CMSFrontendComponent):
         parent_classes = []
         mixins = ["Background", "Spacing", "Attributes"]
         default_config = {
+            "background_context": "secondary",
             "padding_y": "py-6",
         }
         frontend_editable_fields = ("main_heading", "eyebrow_text")

--- a/cms_theme/templates/cta/cta_panel.html
+++ b/cms_theme/templates/cta/cta_panel.html
@@ -7,9 +7,12 @@
             {% if instance.eyebrow_text %}<h6 class="overline pb-3 mb-0">{% inline_field instance "eyebrow_text" %}</h6>{% endif %}
             {% if instance.main_heading %}{% inline_field instance "main_heading" "" "safe" %}{% endif %}
             {% if instance.child_plugin_instances %}
-            {% with button_plugin=instance.child_plugin_instances|filter_by_type:"TextLinkPlugin" %}
-                <div class="text-{{ instance.content_alignment }} cta-btn-section">{% render_plugin button_plugin.0 %}</div>
-            {% endwith %}
+                <div class="text-{{ instance.content_alignment }} cta-btn-section mt-6">
+                    {% for plugin in instance.child_plugin_instances %}
+                        {% render_plugin plugin %}
+                        {% if not forloop.last %}<span class="ms-4"></span>{% endif %}
+                    {% endfor %}
+                </div>
             {% endif %}
         </div>
     </div>


### PR DESCRIPTION
## Summary by Sourcery

Update CTA panel component styling and behaviour for child plugins.

Enhancements:
- Render all child plugins in the CTA panel with spacing between them instead of only a filtered text link plugin.
- Set a secondary background context as the default configuration for the CTA panel component.
- fixes #198
