### PR TITLE
fix: Client card was hidden

### DIFF
--- a/cms_theme/apps.py
+++ b/cms_theme/apps.py
@@ -5,7 +5,7 @@ class CmsThemeConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "cms_theme"
 
-    root_plugins = ("TextPlugin", "MDTextPlugin", "Alias")
+    root_plugins = ("TextPlugin", "MDTextPlugin", "Alias", "ClientCardPlugin", )
 
     def ready(self) -> None:
         from cms.plugin_pool import plugin_pool

--- a/cms_theme/templates/cms_theme/cms_components/client_card.html
+++ b/cms_theme/templates/cms_theme/cms_components/client_card.html
@@ -1,5 +1,5 @@
 {% load frontend cms_tags cms_component cms_theme_tags sekizai_tags i18n %}
-{% cms_component "ClientCard" name=_("Client Card") allow_children=True child_classes="TextLinkPlugin"|split mixins="Background|Attributes|Margin"|split %}
+{% cms_component "ClientCard" name=_("Client Card") allow_children=True child_classes="TextLinkPlugin"|split mixins="Background|Attributes|Margin"|split allowed_models="djangocms_stories.PostContent"|split %}
 {% field "client_name" forms.CharField required=True label=_("Client Name") %}
 {% field "color_name" ColorChoiceField required=False label=_("Name Color") initial="dark" %}
 {% field "client_size" forms.CharField required=False label=_("Client Size") %}


### PR DESCRIPTION
## Summary by Sourcery

Expose the client card CMS component at the root level and constrain it to a specific content model for safer usage.

Bug Fixes:
- Ensure the client card plugin is available as a root plugin so it is no longer hidden in the CMS interface.

Enhancements:
- Restrict the client card component to be used only with the PostContent model via allowed_models configuration.