### PR TITLE
fix: Add margin after role in person card

### DIFF
--- a/cms_theme/templates/related_people/person_card.html
+++ b/cms_theme/templates/related_people/person_card.html
@@ -17,7 +17,7 @@
                 <div class="text-uppercase mb-1 overline pb-2">{% inline_field instance "overline" %}</div>
                 <h4>{% inline_field instance "name" %}</h4>
                 {% if instance.role %}
-                    <p class="mb-0">{% inline_field instance "role" %}</p>
+                    <p>{% inline_field instance "role" %}</p>
                 {% endif %}
                 {% if instance.description %}{% inline_field instance "description" "" "safe" %}{% endif %}
                 {% with buttons=instance.child_plugin_instances %}


### PR DESCRIPTION
fixes #230

## Summary by Sourcery

Bug Fixes:
- Restore bottom margin under the role text in the person card so subsequent content is properly spaced.