### PR TITLE
fix: Autoadjust text color to contrast background

### DIFF
--- a/cms_theme/cms_components.py
+++ b/cms_theme/cms_components.py
@@ -412,7 +412,7 @@ class Footer(CMSFrontendComponent):
         render_template = "footer/footer.html"
         allowed_models = ["djangocms_alias.AliasContent"]
         allow_children = True
-        mixins = ["Background", "Spacing", "Attributes"]
+        mixins = ["Spacing", "Attributes"]
         frontend_editable_fields = ("left_label", "middle_label", "right_label")
         slots = (
             Slot("left", _("Links left column"), child_classes=["TextLinkPlugin"]),
@@ -1013,7 +1013,7 @@ class HorizontalPlanCard(CMSFrontendComponent):
         parent_classes = [
             "MembershipPlansPlugin",
         ]
-        mixins = ["Background", "Spacing", "Attributes"]
+        mixins = ["Spacing", "Attributes"]
         frontend_editable_fields = ("card_heading", "card_sub_heading")
 
     card_heading = forms.CharField(

--- a/cms_theme/templates/cta/cta_panel.html
+++ b/cms_theme/templates/cta/cta_panel.html
@@ -1,9 +1,9 @@
 <!-- cms_theme/templates/cms_theme/cms_components/cta_panel.html -->
 {% load static cms_tags cms_theme_tags frontend %}
-<section class="{{ instance.get_classes }} cta-section {% if instance.config.background_grid %}background-grid{% endif %}"
+<section class="{{ instance.get_classes }} {{ instance.background_context|text_bg }} cta-section {% if instance.config.background_grid %}background-grid{% endif %}"
          {{ instance.get_attributes }}>
     <div class="container">
-        <div class="text-{{ instance.content_alignment }} text-white">
+        <div class="text-{{ instance.content_alignment }}">
             {% if instance.eyebrow_text %}<h6 class="overline pb-3 mb-0">{% inline_field instance "eyebrow_text" %}</h6>{% endif %}
             {% if instance.main_heading %}{% inline_field instance "main_heading" "" "safe" %}{% endif %}
             {% if instance.child_plugin_instances %}

--- a/cms_theme/templates/membership/cards/horizontal_plan_card.html
+++ b/cms_theme/templates/membership/cards/horizontal_plan_card.html
@@ -1,5 +1,5 @@
 {% load static cms_tags sekizai_tags frontend cms_theme_tags %}
-<div class="card p-4 bg-dark text-white">
+<div class="card p-4 bg-dark text-white {{ instance.get_classes }}">
     <div class="row align-items-center g-4">
         {% with images=instance.child_plugin_instances|filter_by_type:"ImagePlugin" %}
             {% if images and images|length > 0 %}

--- a/cms_theme/templates/timeline/timeline.html
+++ b/cms_theme/templates/timeline/timeline.html
@@ -1,16 +1,16 @@
-{% load frontend cms_tags sekizai_tags thumbnail %}
+{% load frontend cms_tags cms_theme_tags sekizai_tags thumbnail %}
 
 <section
     id="timeline-{{ instance.pk }}"
-    class="{% if instance.config.background_grid %}background-grid{% endif %} {{ instance.get_classes }}"
+    class="{% if instance.config.background_grid %}background-grid{% endif %} {{ instance.get_classes }} {{ instance.background_context|text_bg }}"
     {{ instance.get_attributes }}
 >
     <div class="container">
         {# Header content: Heading and intro text #}
         <div class="text-center pb-7">
-            <p class="overline text-dark">{{ instance.eyebrow_text }}</p>
-            <h2 class="pt-2 pb-4 mb-0 text-secondary">{{ instance.title }}</h2>
-            <div class="timeline-text text-dark">{{ instance.text|safe }}</div>
+            <p class="overline{% if not instance.background_context %} text-dark{% endif %}">{{ instance.eyebrow_text }}</p>
+            <h2 class="pt-2 pb-4 mb-0{% if not instance.background_context %} text-secondary{% endif %}">{{ instance.title }}</h2>
+            <div class="timeline-text{% if not instance.background_context %} text-dark{% endif %}">{{ instance.text|safe }}</div>
         </div>
 
         {# Timeline items #}

--- a/cms_theme/templatetags/cms_theme_tags.py
+++ b/cms_theme/templatetags/cms_theme_tags.py
@@ -36,6 +36,26 @@ def make_choices(value):
 
 
 @register.filter
+def text_bg(background_context):
+    """Map a background context to a class giving the text sufficient contrast.
+
+    Delegates to Bootstrap's .text-bg-<color> helpers, whose text color is
+    chosen at Sass compile time by color-contrast() against the actual hex
+    value of each entry in $theme-colors. Apply on the same element that
+    receives the bg-* class (e.g. next to instance.get_classes); the color
+    is inherited by all children that don't set their own text-* utility.
+
+    "white" and "transparent" are offered by the Background mixin but are
+    not theme colors, so no helper class is compiled for them.
+    """
+    if not background_context or background_context == "transparent":
+        return ""
+    if background_context == "white":
+        return "text-body"
+    return f"text-bg-{background_context}"
+
+
+@register.filter
 def filter_by_type(plugins, plugin_types):
     """Filter plugins by type(s)
     Usage: plugins|filter_by_type:"CounterPlugin,ImagePlugin"


### PR DESCRIPTION
* fixes #197

## Summary by Sourcery

Improve text color contrast handling based on background context across CMS components and templates.

New Features:
- Introduce a text_bg template filter to derive appropriate Bootstrap text-background helper classes from a background context.

Bug Fixes:
- Ensure timeline and CTA panel text colors automatically adapt to their background for sufficient contrast instead of using fixed text color utilities.

Enhancements:
- Allow horizontal membership plan cards to receive additional classes via instance.get_classes.
- Simplify component mixin configuration for footer and membership offer card components by removing the Background mixin where it is no longer needed.