### PR TITLE
Fix/links in blog header invsible

### DIFF
--- a/backend/static/scss/_hero.scss
+++ b/backend/static/scss/_hero.scss
@@ -10,10 +10,8 @@
     h1 {
       color: $primary;
     }
-    a:hover {
-      color: $white;
-      border-color: $white;
-    }
+    // Link colors (primary text, inverted pill on hover) are handled globally
+    // for all dark backgrounds in _links.scss.
   }
 
   .hero-content-right {

--- a/backend/static/scss/_links.scss
+++ b/backend/static/scss/_links.scss
@@ -5,8 +5,6 @@
 // Global link base styles
 a {
   font-weight: 400;
-  font-size: 16px;
-  line-height: 24px;
   letter-spacing: 0;
   color: $secondary;
   text-decoration: none !important;
@@ -87,6 +85,22 @@ footer .bg-dark a,
   &:focus {
     color: $secondary !important;
     text-decoration: none;
+  }
+}
+
+// Links on dark backgrounds (hero, cards, features, …)
+// Inverted pill: primary text by default, primary pill with secondary text on hover.
+#{$dark-bg-selectors} {
+  a:not(.btn):not(.nav-link):not(.link-white):not(.link-light):not(.card-author-link):not(.card-event-link) {
+    color: $primary;
+
+    &:hover,
+    &:focus,
+    &:active,
+    &.active {
+      color: $secondary;
+      background-color: $primary;
+    }
   }
 }
 

--- a/backend/static/scss/_list_style.scss
+++ b/backend/static/scss/_list_style.scss
@@ -136,6 +136,26 @@ ol ol > li {
 }
 
 // ==============================================
+// Dark backgrounds – list markers use primary for contrast
+// (squares/dashes via background-color, numbers/letters via color)
+#{$dark-bg-selectors} {
+  ul > li::before,
+  .list-bullet > li::before,
+  ul.list-styled > li::before,
+  .list-dash > li::before,
+  ul.list-styled-dash > li::before {
+    background-color: $primary;
+  }
+
+  ol:not(.list-unstyled):not(.breadcrumb) > li::before,
+  .list-numbered > li::before,
+  ol.list-styled > li::before,
+  ol ol > li::before {
+    color: $primary;
+  }
+}
+
+// ==============================================
 // CMS Toolbar & Frontend List Style Reset
 .cms-toolbar,
 .djangocms-frontend {

--- a/backend/static/scss/_variables.scss
+++ b/backend/static/scss/_variables.scss
@@ -51,6 +51,10 @@ $list-group-active-bg: $primary;
 $list-group-active-color: $secondary;
 $list-group-active-border-color: $primary;
 
+// Background utility classes that render light text on a dark surface.
+// Used to invert link colors (primary text, primary pill on hover).
+$dark-bg-selectors: ".bg-secondary, .bg-dark, .bg-second-primary, .bg-dark-green, .bg-black";
+
 // Custom colors
 $mid-grey: #7C7C7C;
 $dark-green: #1a4d2e;


### PR DESCRIPTION
This pull request refactors how link colors are styled on dark backgrounds to improve consistency and maintainability. The main changes include moving link hover styling from the `_hero.scss` file to a new, centralized rule in `_links.scss`, and introducing a `$dark-bg-selectors` variable for easier management of dark background selectors.

**Centralization and Consistency of Link Styles:**

* Moved link hover color and border styling for `.hero` sections out of `_hero.scss`, with a comment noting that these are now handled globally for all dark backgrounds in `_links.scss`.
* Added a global rule in `_links.scss` applying consistent link and hover styles on all dark backgrounds specified by `$dark-bg-selectors`, ensuring primary text by default and a primary pill with secondary text on hover.
* Introduced the `$dark-bg-selectors` variable in `_variables.scss` to centralize and simplify the list of selectors that represent dark backgrounds.

**Minor Style Adjustments:**

* Removed explicit `font-size` and `line-height` from the base link styles in `_links.scss` for cleaner global link styling.

## [Timeline](https://github.com/django-cms/django-cms.org/issues/221)

### #221 #202 

<img width="773" height="291" alt="image" src="https://github.com/user-attachments/assets/c3e7de58-27d4-4b49-819c-127b25b98ace" />
<img width="1096" height="481" alt="image" src="https://github.com/user-attachments/assets/59d28c3b-dc8a-4526-89bf-e0aaec6b5bf4" />

<img width="395" height="403" alt="image" src="https://github.com/user-attachments/assets/bfd78b09-fd25-4c84-9a88-f19809f91ff2" />



## [Hero](https://github.com/django-cms/django-cms.org/issues/206)

### #206 

<img width="513" height="205" alt="image" src="https://github.com/user-attachments/assets/6593027b-360c-460c-b36f-af1493126eb3" />
<img width="1621" height="416" alt="image" src="https://github.com/user-attachments/assets/2c24a5d9-f829-409c-831e-378f3d7e6647" />



## [Headlines with Links](https://github.com/django-cms/django-cms.org/issues/204)

### #204 

<img width="1020" height="92" alt="image" src="https://github.com/user-attachments/assets/aebe4900-80f3-4111-8f6a-ad2347116e76" />
<img width="1620" height="303" alt="image" src="https://github.com/user-attachments/assets/331bdb72-4171-459d-8c9c-b7daeb05e383" />

## Summary by Sourcery

Centralize and standardize link styling on dark backgrounds to ensure visible, consistent link appearance across hero and other dark sections.

Enhancements:
- Remove fixed typography from base link styles to allow more flexible link sizing across the site.
- Introduce a shared $dark-bg-selectors variable to define dark background contexts in one place and reuse them in link styling.
- Apply unified inverted-pill link styling for non-button links on dark backgrounds, and delegate hero-specific link colors to this global rule.