### PR TITLE
fix: Accordion line-height

### DIFF
--- a/backend/static/scss/_accordion.scss
+++ b/backend/static/scss/_accordion.scss
@@ -56,6 +56,7 @@
       padding: 1.5rem 0;
       font-weight: 400;
       font-size: 2.25rem;
+      line-height: 1.25;
       border-radius: 0;
       transition: none; // Disable transition, will be handled by JS
       width: 100%;


### PR DESCRIPTION
* fixes #224

## Summary by Sourcery

Enhancements:
- Set a specific line-height for accordion headers to ensure consistent text spacing.