### PR TITLE
feat: Add missing alt attributes

### DIFF
--- a/backend/templates/blog/includes/card_image_top.html
+++ b/backend/templates/blog/includes/card_image_top.html
@@ -6,7 +6,7 @@
       {% thumbnail post_content.post.main_image 400x241 crop="smart" quality=55 subject_location=post_content.post.main_image.subject_location as hero_sm %}
       {% thumbnail post_content.post.main_image 600x362 crop="smart" quality=55 subject_location=post_content.post.main_image.subject_location as hero_md %}
       {% thumbnail post_content.post.main_image 800x482 crop="smart" quality=55 subject_location=post_content.post.main_image.subject_location as hero_lg %}
-            <img src="{{ hero_md.url }}"
+            <img src="{{ hero_md.url }}" alt="{{ hero_md.default_alt_text|default_if_none:'' }}"
                  srcset="{{ hero_sm.url }} 400w, {{ hero_md.url }} 600w, {{ hero_lg.url }} 800w"
                  sizes="(max-width: 576px) 400px, (max-width: 992px) 600px, 800px"
                  class="card-img-top blog-img-top"

--- a/cms_theme/templates/cms_theme/person/default/person.html
+++ b/cms_theme/templates/cms_theme/person/default/person.html
@@ -1,5 +1,5 @@
 <div class="person text-center">
-    <img src="{{ instance.img_src }}" class="rounded-circle" />
+    <img src="{{ instance.img_src }}" alt="{{ instance.name }}" class="rounded-circle" />
     <div class="name">{{ instance.name }}</div>
     {% if instance.role %}
         <div class="role text-muted">{{ instance.role }}</div>

--- a/cms_theme/templates/djangocms_frontend/bootstrap5/cards/top_image/card.html
+++ b/cms_theme/templates/djangocms_frontend/bootstrap5/cards/top_image/card.html
@@ -8,7 +8,7 @@
         {% endif %}
         {% if instance.bottom_image %}
             <div class="benefits-card-top-image">
-                <img src="{{ instance.bottom_image.url }}" alt="" class="w-100 d-block">
+                <img src="{{ instance.bottom_image.url }}" alt="{{ instance.bottom_image.default_alt_text|default_if_none:'' }}" class="w-100 d-block">
             </div>
         {% endif %}
         {% if instance.card_title %}

--- a/cms_theme/templates/footer/footer.html
+++ b/cms_theme/templates/footer/footer.html
@@ -5,7 +5,7 @@
     <div class="container">
         <div class="row cms-plugin">
             <div class="col-12 col col-md-6">
-                <img src="{% static 'cms/fonts/src/logo.svg' %}" height="35" class="img-fluid logo-invert">
+                <img src="{% static 'cms/fonts/src/logo.svg' %}" alt="django CMS" height="35" class="img-fluid logo-invert">
             </div>
 
             <div class="col-12 my-lg-0 col col-md-2 py-1 my-4 py-lg-0">


### PR DESCRIPTION
## Summary by Sourcery

Add descriptive alt text to various template images to improve accessibility and SEO.

New Features:
- Provide alt text for blog card hero images using the thumbnail default alt metadata.
- Set person image alt text to the person instance name in the person template.
- Use bottom_image default alt metadata as alt text in benefits card templates.
- Add a fixed descriptive alt text for the footer logo image.