### PR TITLE
feat: Add frontend-editing for stories

### DIFF
--- a/backend/templates/blog/includes/card_author.html
+++ b/backend/templates/blog/includes/card_author.html
@@ -5,13 +5,13 @@
         <div class="card-body d-flex flex-column">
             <p class="overline pb-2 mb-1 text-secondary">{{ post_content.post.categories.first }}</p>
             <h4 class="text-secondary pb-2 mb-1">
-                {{ post_content.title }}
+                {% render_model post_content "title" "title" %}
             </h4>
             {% if post_content.subtitle %}
                 <small>{{ post_content.subtitle }}</small>
             {% endif %}
             <div class="card-text text-secondary pt-3 pb-2">
-                {% render_model post_content "abstract" "" "" "truncatewords_html:20|safe"  %}
+                {% render_model post_content "abstract" "abstract" "" "truncatewords_html:20|safe"  %}
             </div>
             <div class="d-flex flex-row mt-auto pt-4" style="gap: 34px;">
                 {% with post_content.author.author_profile as profile %}
@@ -44,7 +44,9 @@
                 {% endif %}
                 {% endwith %}
             </div>
-            <a href="{% absolute_url post_content %}" class="stretched-link" aria-label="{{ profile.name|escapejs }}"></a>
+            {% if not request.toolbar.edit_mode_active %}
+                <a href="{% absolute_url post_content %}" class="stretched-link" aria-label="{{ profile.name|escapejs }}"></a>
+            {% endif %}
         </div>
     </div>
 </article>

--- a/backend/templates/blog/includes/card_image_top.html
+++ b/backend/templates/blog/includes/card_image_top.html
@@ -14,12 +14,12 @@
       {% endif %}
   <div class="card-body d-flex flex-column text-secondary">
     <p class="overline pb-1 mb-0">{{ post_content.post.categories.first }}</p>
-    <h4 class="card-title pt-2 mb-0">{{ post_content.title }}</h4>
+    <h4 class="card-title pt-2 mb-0">{% render_model post_content "title" "title" %}</h4>
     <div class="card-text pt-3 pb-2">
         {% if not TRUNCWORDS_COUNT %}
-            {% render_model post_content "abstract" "" "" "safe" %}
+            {% render_model post_content "abstract" "abstract" "" "safe" %}
         {% else %}
-            {% render_model post_content "abstract" "" "" "truncatewords_html:TRUNCWORDS_COUNT|safe"  %}
+            {% render_model post_content "abstract" "abstract" "" "truncatewords_html:TRUNCWORDS_COUNT|safe"  %}
         {% endif %}
     </div>
     <div class="mt-auto pt-4">

--- a/backend/templates/blog/includes/events.html
+++ b/backend/templates/blog/includes/events.html
@@ -14,12 +14,12 @@
                 <div class="{% if image and post_content.post.main_image %}col-md-8{% else %}col-12{% endif %}">
                     <div class="card-body d-flex flex-column text-secondary">
                         <p class="overline pb-1 mb-0">{{ post_content.post.categories.first }}</p>
-                        <h5 class="card-title pt-2 mb-0">{{ post_content.title }}</h5>
+                        <h5 class="card-title pt-2 mb-0">{% render_model post_content "title" "title" %}</h5>
                         <div class="card-text pt-3 pb-2 mb-0">
                             {% if not TRUNCWORDS_COUNT %}
-                                {% render_model post_content "abstract" "" "" "safe" %}
+                                {% render_model post_content "abstract" "abstract" "" "safe" %}
                             {% else %}
-                                {% render_model post_content "abstract" "" "" "truncatewords_html:TRUNCWORDS_COUNT|safe" %}
+                                {% render_model post_content "abstract" "abstract" "" "truncatewords_html:TRUNCWORDS_COUNT|safe" %}
                             {% endif %}
                         </div>
                         <div class="d-flex flex-column gap-2 mt-4 pt-1 text-black">

--- a/backend/templates/blog/includes/hero_detail.html
+++ b/backend/templates/blog/includes/hero_detail.html
@@ -7,11 +7,11 @@
                     <span class="overline text-primary">{{ post_content.post.categories.first }}{% if post_content.post.date_published and not post_content.post.date_featured %} | {{post_content.post.date_published|date:"F j, Y" }}{% endif %}</span>
                 <div class="row">
                     <div class="col-12 col-lg-11">
-                        <h1 class="mt-2 mb-0 pb-4 text-primary">{{ post_content.title }}</h1>
+                        <h1 class="mt-2 mb-0 pb-4 text-primary">{% render_model post_content "title" "title" %}</h1>
                     </div>
                 </div>
-                {% if post_content.abstract %}
-                    <div class="fs-5 pb-2 text-white col-12 col-lg-11">{{ post_content.abstract }}</div>
+                {% if post_content.abstract or request.toolbar.edit_mode_active %}
+                    <div class="fs-5 pb-2 text-white col-12 col-lg-11">{% render_model post_content "abstract" "abstract" "" "safe" %}</div>
                 {% endif %}
                 {% if post_content.post.date_featured %}
                     <div class="pt-3 mt-2">

--- a/backend/templates/blog/includes/post_item.html
+++ b/backend/templates/blog/includes/post_item.html
@@ -2,7 +2,9 @@
 
 <article id="post-{{ post_content.slug }}" class="post-item post-item-list">
     <div class="card box-shadow-card bg-light mb-3 {% if image and post_content.post.main_image %}post-item-list-height-with-img{% else %}post-item-list-height{% endif %}">
-        <a href="{% absolute_url post_content %}" class="stretched-link" arial-label="{{ post_content.title|escapejs }}"></a>
+        {% if not request.toolbar.edit_mode_active %}
+            <a href="{% absolute_url post_content %}" class="stretched-link" arial-label="{{ post_content.title|escapejs }}"></a>
+        {% endif %}
         <div class="row g-0">
             {% if image and post_content.post.main_image %}
                 <div class="col-md-4">
@@ -21,15 +23,15 @@
             <div class="{% if image and post_content.post.main_image %}col-md-8{% else %}col-12{% endif %} post-list-spacing">
                 <div class="card-body text-secondary">
                     <p class="overline pb-1">{{ post_content.post.categories.first }}</p>
-                    <h5 class="card-title pt-2 pb-4 mb-1">{{ post_content.title }}</h5>
+                    <h5 class="card-title pt-2 pb-4 mb-1">{% render_model post_content "title" "title" %}</h5>
                     {% if post_content.subtitle %}
                         <p>{{ post_content.subtitle }}</p>
                     {% endif %}
                     <p class="card-text">
                         {% if not TRUNCWORDS_COUNT %}
-                            {% render_model post_content "abstract" "" "" "safe" %}
+                            {% render_model post_content "abstract" "abstract" "" "safe" %}
                         {% else %}
-                            {% render_model post_content "abstract" "" "" "truncatewords_html:TRUNCWORDS_COUNT|safe"  %}
+                            {% render_model post_content "abstract" "abstract" "" "truncatewords_html:TRUNCWORDS_COUNT|safe"  %}
                         {% endif %}
                     </p>
                     {% if post_content.post.date_featured %}


### PR DESCRIPTION
## Summary by Sourcery

Enable frontend editing for story titles and abstracts while preserving normal story navigation outside edit mode.

New Features:
- Enable inline editing of story titles and abstracts throughout blog cards, listings, event cards, and detail heroes.
- Keep story cards editable in frontend edit mode by disabling their stretched navigation links.

Enhancements:
- Ensure empty abstracts remain available for editing in the story detail hero.