### PR TITLE
fix: Remove n+1 queries from blog list views

### DIFF
--- a/backend/blog_urls.py
+++ b/backend/blog_urls.py
@@ -2,14 +2,29 @@ from django.urls import path
 
 from djangocms_stories.urls import urlpatterns as stories_urlpatterns
 
-from .views import SearchPostListView
+from .views import (
+    OptimizedAuthorEntriesView,
+    OptimizedCategoryEntriesView,
+    OptimizedPostArchiveView,
+    OptimizedTaggedListView,
+    SearchPostListView,
+)
 
 app_name = "djangocms_stories"
 
-# Start with our search-enabled list view
-urlpatterns = [
-    path("", SearchPostListView.as_view(), name="posts-latest"),
-]
+# List routes we replace with query-optimized subclasses (see OptimizedListMixin).
+_optimized = {
+    "posts-latest": SearchPostListView,
+    "posts-category": OptimizedCategoryEntriesView,
+    "posts-archive": OptimizedPostArchiveView,
+    "posts-author": OptimizedAuthorEntriesView,
+    "posts-tagged": OptimizedTaggedListView,
+}
 
-# Add all other original URL patterns (skip the original posts-latest)
-urlpatterns += [p for p in stories_urlpatterns if p.name != "posts-latest"]
+urlpatterns = []
+for p in stories_urlpatterns:
+    view = _optimized.get(p.name)
+    if view is not None:
+        urlpatterns.append(path(str(p.pattern), view.as_view(), name=p.name))
+    else:
+        urlpatterns.append(p)

--- a/backend/templates/blog/includes/card_author.html
+++ b/backend/templates/blog/includes/card_author.html
@@ -3,7 +3,7 @@
 <article id="post-{{ post_content.slug }}" class="post-item h-100">
     <div class="card bg-white shadow-sm h-100 text-decoration-none text-reset card-author-link">
         <div class="card-body d-flex flex-column">
-            <p class="overline pb-2 mb-1 text-secondary">{{ post_content.post.categories.first }}</p>
+            <p class="overline pb-2 mb-1 text-secondary">{{ post_content.post.categories.all|first }}</p>
             <h4 class="text-secondary pb-2 mb-1">
                 {{ post_content.title }}
             </h4>

--- a/backend/templates/blog/includes/card_image_top.html
+++ b/backend/templates/blog/includes/card_image_top.html
@@ -13,7 +13,7 @@
                  alt="{{ post_content.post.main_image.default_alt_text|default_if_none:'' }}" />
       {% endif %}
   <div class="card-body d-flex flex-column text-secondary">
-    <p class="overline pb-1 mb-0">{{ post_content.post.categories.first }}</p>
+    <p class="overline pb-1 mb-0">{{ post_content.post.categories.all|first }}</p>
     <h4 class="card-title pt-2 mb-0">{{ post_content.title }}</h4>
     <div class="card-text pt-3 pb-2">
         {% if not TRUNCWORDS_COUNT %}

--- a/backend/templates/blog/includes/post_item.html
+++ b/backend/templates/blog/includes/post_item.html
@@ -20,7 +20,7 @@
             {% endif %}
             <div class="{% if image and post_content.post.main_image %}col-md-8{% else %}col-12{% endif %} post-list-spacing">
                 <div class="card-body text-secondary">
-                    <p class="overline pb-1">{{ post_content.post.categories.first }}</p>
+                    <p class="overline pb-1">{{ post_content.post.categories.all|first }}</p>
                     <h5 class="card-title pt-2 pb-4 mb-1">{{ post_content.title }}</h5>
                     {% if post_content.subtitle %}
                         <p>{{ post_content.subtitle }}</p>

--- a/backend/templatetags/blog_tags.py
+++ b/backend/templatetags/blog_tags.py
@@ -10,7 +10,11 @@ register = template.Library()
 
 @register.simple_tag
 def get_blog_categories():
-    return PostCategory.objects.order_by("priority", "translations__name")
+    return (
+        PostCategory.objects
+        .prefetch_related("translations")
+        .order_by("priority", "translations__name")
+    )
 
 
 @register.simple_tag(takes_context=True)

--- a/backend/views.py
+++ b/backend/views.py
@@ -1,9 +1,35 @@
 from django.db.models import Q
 
-from djangocms_stories.views import PostListView
+from djangocms_stories.views import (
+    AuthorEntriesView,
+    CategoryEntriesView,
+    PostArchiveView,
+    PostListView,
+    TaggedListView,
+)
 
 
-class SearchPostListView(PostListView):
+class OptimizedListMixin:
+    """Extend the library's list-view query optimization for our templates.
+
+    The base ``optimize()`` only covers ``post__app_config`` and
+    ``post__categories``. Our blog list templates additionally render, per post,
+    the main image (``post_item.html`` / ``card_image_top.html``) and the author
+    profile with its photo (``card_author.html``). Pulling those in avoids an
+    N+1 query per post in the list. All paths are nullable FKs / a reverse
+    OneToOne, so select_related uses LEFT JOINs.
+    """
+
+    def optimize(self, qs):
+        return super().optimize(qs).select_related(
+            "post__main_image",
+            "post__author",
+            "post__author__author_profile",
+            "post__author__author_profile__photo",
+        )
+
+
+class SearchPostListView(OptimizedListMixin, PostListView):
     """Extends PostListView with ?q= search filtering on title and abstract."""
 
     def get_queryset(self):
@@ -19,3 +45,19 @@ class SearchPostListView(PostListView):
         context = super().get_context_data(**kwargs)
         context["search_query"] = self.request.GET.get("q", "").strip()
         return context
+
+
+class OptimizedPostArchiveView(OptimizedListMixin, PostArchiveView):
+    pass
+
+
+class OptimizedTaggedListView(OptimizedListMixin, TaggedListView):
+    pass
+
+
+class OptimizedAuthorEntriesView(OptimizedListMixin, AuthorEntriesView):
+    pass
+
+
+class OptimizedCategoryEntriesView(OptimizedListMixin, CategoryEntriesView):
+    pass


### PR DESCRIPTION
## Summary by Sourcery

Introduce optimized blog list views to reduce N+1 queries when rendering posts and categories.

New Features:
- Add an OptimizedListMixin and optimized subclasses for archive, tagged, author, category, and search post list views.

Enhancements:
- Update blog URL routing to swap standard djangocms_stories list views for optimized equivalents based on route name.
- Prefetch category translations in the get_blog_categories template tag to improve query efficiency.
- Align templates to access the first category via the full categories queryset for consistency with optimized queries.