### PR TITLE
fix: Remove broken inline-editing

### DIFF
--- a/backend/templates/blog/includes/card_author.html
+++ b/backend/templates/blog/includes/card_author.html
@@ -5,13 +5,13 @@
         <div class="card-body d-flex flex-column">
             <p class="overline pb-2 mb-1 text-secondary">{{ post_content.post.categories.all|first }}</p>
             <h4 class="text-secondary pb-2 mb-1">
-                {% render_model post_content "title" "title" %}
+                {{ post_content.title }}
             </h4>
             {% if post_content.subtitle %}
                 <small>{{ post_content.subtitle }}</small>
             {% endif %}
             <div class="card-text text-secondary pt-3 pb-2">
-                {% render_model post_content "abstract" "abstract" "" "truncatewords_html:20|safe"  %}
+                {{ post_content.abstract|truncatewords_html:20|safe }}
             </div>
             <div class="d-flex flex-row mt-auto pt-4" style="gap: 34px;">
                 {% with post_content.author.author_profile as profile %}

--- a/backend/templates/blog/includes/card_image_top.html
+++ b/backend/templates/blog/includes/card_image_top.html
@@ -14,12 +14,12 @@
       {% endif %}
   <div class="card-body d-flex flex-column text-secondary">
     <p class="overline pb-1 mb-0">{{ post_content.post.categories.first }}</p>
-    <h4 class="card-title pt-2 mb-0">{% render_model post_content "title" "title" %}</h4>
+    <h4 class="card-title pt-2 mb-0">{{ post_content.title }}</h4>
     <div class="card-text pt-3 pb-2">
         {% if not TRUNCWORDS_COUNT %}
-            {% render_model post_content "abstract" "abstract" "" "safe" %}
+            {{ post_content.abstract|safe }}
         {% else %}
-            {% render_model post_content "abstract" "abstract" "" "truncatewords_html:TRUNCWORDS_COUNT|safe"  %}
+            {{ post_content.abstract|truncatewords_html:TRUNCWORDS_COUNT|safe }}
         {% endif %}
     </div>
     <div class="mt-auto pt-4">

--- a/backend/templates/blog/includes/events.html
+++ b/backend/templates/blog/includes/events.html
@@ -14,19 +14,19 @@
                 <div class="{% if image and post_content.post.main_image %}col-md-8{% else %}col-12{% endif %}">
                     <div class="card-body d-flex flex-column text-secondary">
                         <p class="overline pb-1 mb-0">{{ post_content.post.categories.first }}</p>
-                        <h5 class="card-title pt-2 mb-0">{% render_model post_content "title" "title" %}</h5>
+                        <h5 class="card-title pt-2 mb-0">{{ post_conent.title }}</h5>
                         <div class="card-text pt-3 pb-2 mb-0">
                             {% if not TRUNCWORDS_COUNT %}
-                                {% render_model post_content "abstract" "abstract" "" "safe" %}
+                            {{ post_content.abstract|safe }}
                             {% else %}
-                                {% render_model post_content "abstract" "abstract" "" "truncatewords_html:TRUNCWORDS_COUNT|safe" %}
+                                {{ post_content.abstract|truncatewords_html:TRUNCWORDS_COUNT|safe }}
                             {% endif %}
                         </div>
                         <div class="d-flex flex-column gap-2 mt-4 pt-1 text-black">
                             {% if post_content.post.date_featured %}
                                 <span class="event-location d-flex align-items-center gap-2">
                                     <i class="bi bi-geo-alt fs-5"></i> Online
-                                </span>                      
+                                </span>
                                 <span class="event-date d-flex align-items-center gap-2">
                                     <i class="bi bi-calendar4 fs-5"></i>
                                     {{ post_content.post.date_featured|date:"jS F, Y" }}

--- a/backend/templates/blog/includes/events.html
+++ b/backend/templates/blog/includes/events.html
@@ -14,7 +14,7 @@
                 <div class="{% if image and post_content.post.main_image %}col-md-8{% else %}col-12{% endif %}">
                     <div class="card-body d-flex flex-column text-secondary">
                         <p class="overline pb-1 mb-0">{{ post_content.post.categories.first }}</p>
-                        <h5 class="card-title pt-2 mb-0">{{ post_conent.title }}</h5>
+                        <h5 class="card-title pt-2 mb-0">{{ post_content.title }}</h5>
                         <div class="card-text pt-3 pb-2 mb-0">
                             {% if not TRUNCWORDS_COUNT %}
                             {{ post_content.abstract|safe }}

--- a/backend/templates/blog/includes/post_item.html
+++ b/backend/templates/blog/includes/post_item.html
@@ -2,9 +2,7 @@
 
 <article id="post-{{ post_content.slug }}" class="post-item post-item-list">
     <div class="card box-shadow-card bg-light mb-3 {% if image and post_content.post.main_image %}post-item-list-height-with-img{% else %}post-item-list-height{% endif %}">
-        {% if not request.toolbar.edit_mode_active %}
-            <a href="{% absolute_url post_content %}" class="stretched-link" arial-label="{{ post_content.title|escapejs }}"></a>
-        {% endif %}
+        <a href="{% absolute_url post_content %}" class="stretched-link" arial-label="{{ post_content.title|escapejs }}"></a>
         <div class="row g-0">
             {% if image and post_content.post.main_image %}
                 <div class="col-md-4">
@@ -23,15 +21,15 @@
             <div class="{% if image and post_content.post.main_image %}col-md-8{% else %}col-12{% endif %} post-list-spacing">
                 <div class="card-body text-secondary">
                     <p class="overline pb-1">{{ post_content.post.categories.first }}</p>
-                    <h5 class="card-title pt-2 pb-4 mb-1">{% render_model post_content "title" "title" %}</h5>
+                    <h5 class="card-title pt-2 pb-4 mb-1">{{ post_content.title }}</h5>
                     {% if post_content.subtitle %}
                         <p>{{ post_content.subtitle }}</p>
                     {% endif %}
                     <p class="card-text">
                         {% if not TRUNCWORDS_COUNT %}
-                            {% render_model post_content "abstract" "abstract" "" "safe" %}
+                            {{ post_content.abstract|safe }}
                         {% else %}
-                            {% render_model post_content "abstract" "abstract" "" "truncatewords_html:TRUNCWORDS_COUNT|safe"  %}
+                            {{ post_content.abstract|truncatewords_html:TRUNCWORDS_COUNT|safe }}
                         {% endif %}
                     </p>
                     {% if post_content.post.date_featured %}

--- a/backend/templates/blog/includes/post_item.html
+++ b/backend/templates/blog/includes/post_item.html
@@ -2,7 +2,7 @@
 
 <article id="post-{{ post_content.slug }}" class="post-item post-item-list">
     <div class="card box-shadow-card bg-light mb-3 {% if image and post_content.post.main_image %}post-item-list-height-with-img{% else %}post-item-list-height{% endif %}">
-        <a href="{% absolute_url post_content %}" class="stretched-link" arial-label="{{ post_content.title|escapejs }}"></a>
+        <a href="{% absolute_url post_content %}" class="stretched-link" aria-label="{{ post_content.title|escapejs }}"></a>
         <div class="row g-0">
             {% if image and post_content.post.main_image %}
                 <div class="col-md-4">


### PR DESCRIPTION
## Summary by Sourcery

Remove broken inline editing from blog cards and restore consistent post content rendering.

Bug Fixes:
- Remove broken inline-editing controls from blog content cards while preserving normal post navigation.

Enhancements:
- Render post titles and abstracts directly in blog card templates for consistent read-only display.