### PR TITLE
feat: Redirect django-cms.org, django-cms.com to www.django-cms.org

### DIFF
--- a/backend/middleware.py
+++ b/backend/middleware.py
@@ -22,9 +22,7 @@ class CanonicalHostRedirectMiddleware:
 
     def __init__(self, get_response):
         self.get_response = get_response
-        self.canonical_host = getattr(
-            settings, "CANONICAL_HOST", "www.django-cms.org"
-        )
+        self.canonical_host = getattr(settings, "CANONICAL_HOST", "www.django-cms.org")
         self.aliases = {
             alias.lower()
             for alias in getattr(

--- a/backend/middleware.py
+++ b/backend/middleware.py
@@ -1,7 +1,58 @@
+from urllib.parse import urlunsplit
+
+from django.conf import settings
 from django.contrib.redirects.middleware import RedirectFallbackMiddleware
 from django.contrib.redirects.models import Redirect
 from django.contrib.sites.shortcuts import get_current_site
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseRedirect, HttpResponsePermanentRedirect
+
+
+class CanonicalHostRedirectMiddleware:
+    """Redirect alias domains to the canonical host, keeping path and query string.
+
+    ``django-cms.org`` and ``django-cms.com`` (configurable through
+    ``CANONICAL_HOST_ALIASES``) are answered with a permanent redirect to the
+    same URL on ``CANONICAL_HOST``. Ports are ignored when matching, so
+    ``django-cms.org:8000`` redirects as well.
+
+    Runs before ``SecurityMiddleware`` so an insecure request to an alias takes
+    a single hop: the redirect already points at HTTPS whenever
+    ``SECURE_SSL_REDIRECT`` is on or the request itself is secure.
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+        self.canonical_host = getattr(
+            settings, "CANONICAL_HOST", "www.django-cms.org"
+        )
+        self.aliases = {
+            alias.lower()
+            for alias in getattr(
+                settings,
+                "CANONICAL_HOST_ALIASES",
+                ("django-cms.org", "django-cms.com"),
+            )
+        }
+
+    def __call__(self, request):
+        host = request.get_host().split(":")[0].lower()
+        if host in self.aliases:
+            scheme = (
+                "https"
+                if request.is_secure() or settings.SECURE_SSL_REDIRECT
+                else "http"
+            )
+            target = urlunsplit(
+                (
+                    scheme,
+                    self.canonical_host,
+                    request.path,
+                    request.META.get("QUERY_STRING", ""),
+                    "",
+                )
+            )
+            return HttpResponsePermanentRedirect(target)
+        return self.get_response(request)
 
 
 class PathOnlyRedirectFallbackMiddleware(RedirectFallbackMiddleware):

--- a/backend/settings.py
+++ b/backend/settings.py
@@ -56,6 +56,14 @@ if DEBUG:
         "*",
     ]
 
+# Alias domains redirected to the canonical host by
+# backend.middleware.CanonicalHostRedirectMiddleware.
+CANONICAL_HOST = os.environ.get("CANONICAL_HOST", "www.django-cms.org")
+CANONICAL_HOST_ALIASES = [
+    "django-cms.org",
+    "django-cms.com",
+]
+
 # Redirect to HTTPS by default, unless explicitly disabled
 SECURE_SSL_REDIRECT = os.environ.get("SECURE_SSL_REDIRECT") != "False"
 
@@ -131,6 +139,9 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
+    # Sends alias domains to the canonical host (must be first, so the redirect
+    # happens before any other middleware does work on the request).
+    "backend.middleware.CanonicalHostRedirectMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",

--- a/backend/tests/test_middleware.py
+++ b/backend/tests/test_middleware.py
@@ -1,0 +1,78 @@
+from django.http import HttpResponse
+from django.test import RequestFactory, SimpleTestCase, override_settings
+
+from backend.middleware import CanonicalHostRedirectMiddleware
+
+
+def _middleware():
+    return CanonicalHostRedirectMiddleware(lambda request: HttpResponse("ok"))
+
+
+@override_settings(
+    ALLOWED_HOSTS=["*"],
+    CANONICAL_HOST="www.django-cms.org",
+    CANONICAL_HOST_ALIASES=["django-cms.org", "django-cms.com"],
+    SECURE_SSL_REDIRECT=True,
+)
+class CanonicalHostRedirectMiddlewareTests(SimpleTestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_alias_hosts_redirect_to_canonical_host(self):
+        for host in ("django-cms.org", "django-cms.com", "DJANGO-CMS.ORG"):
+            with self.subTest(host=host):
+                request = self.factory.get("/en/features/", HTTP_HOST=host)
+
+                response = _middleware()(request)
+
+                self.assertEqual(response.status_code, 301)
+                self.assertEqual(
+                    response["Location"],
+                    "https://www.django-cms.org/en/features/",
+                )
+
+    def test_query_string_is_preserved(self):
+        request = self.factory.get(
+            "/en/faq/",
+            {"utm_source": "newsletter", "page": "2"},
+            HTTP_HOST="django-cms.org",
+        )
+
+        response = _middleware()(request)
+
+        self.assertEqual(
+            response["Location"],
+            "https://www.django-cms.org/en/faq/?utm_source=newsletter&page=2",
+        )
+
+    def test_port_is_ignored_when_matching(self):
+        request = self.factory.get("/", HTTP_HOST="django-cms.org:8000")
+
+        response = _middleware()(request)
+
+        self.assertEqual(response["Location"], "https://www.django-cms.org/")
+
+    def test_canonical_host_is_served_normally(self):
+        for host in ("www.django-cms.org", "www.django-cms.com", "localhost"):
+            with self.subTest(host=host):
+                request = self.factory.get("/en/", HTTP_HOST=host)
+
+                response = _middleware()(request)
+
+                self.assertEqual(response.status_code, 200)
+
+    @override_settings(SECURE_SSL_REDIRECT=False)
+    def test_insecure_request_keeps_scheme_when_ssl_redirect_is_off(self):
+        request = self.factory.get("/", HTTP_HOST="django-cms.com")
+
+        response = _middleware()(request)
+
+        self.assertEqual(response["Location"], "http://www.django-cms.org/")
+
+    @override_settings(SECURE_SSL_REDIRECT=False)
+    def test_secure_request_stays_secure(self):
+        request = self.factory.get("/", HTTP_HOST="django-cms.com", secure=True)
+
+        response = _middleware()(request)
+
+        self.assertEqual(response["Location"], "https://www.django-cms.org/")


### PR DESCRIPTION
## Summary by Sourcery

Redirect django-cms.org and django-cms.com traffic to the canonical www.django-cms.org domain.

New Features:
- Redirect requests from configured alias domains to the canonical www.django-cms.org host while preserving paths and query strings.

Enhancements:
- Configure canonical host aliases through settings and preserve the appropriate HTTP or HTTPS scheme in a single permanent redirect.

Tests:
- Add coverage for alias matching, case-insensitivity, ports, query strings, scheme handling, and normal canonical-host requests.